### PR TITLE
Keep DM Tools visible and add logout control

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,6 +124,7 @@
              <div id="dm-tools-dropdown" class="hidden absolute right-0 mt-2 w-56 bg-black cli-window">
                  <button id="create-new-shop-btn" class="dropdown-link mb-2">> Create New Shop</button>
                  <button id="view-keys-btn" class="dropdown-link">> View Character Keys</button>
+                 <button id="logout-btn" class="dropdown-link hidden">> Logout</button>
              </div>
              <button id="exit-mode-btn" class="hidden">ⓧ</button>
         </div>
@@ -231,6 +232,7 @@
         const dmToolsDropdown = document.getElementById('dm-tools-dropdown');
         const createNewShopBtn = document.getElementById('create-new-shop-btn');
         const viewKeysBtn = document.getElementById('view-keys-btn');
+        const logoutBtn = document.getElementById('logout-btn');
         const exitModeBtn = document.getElementById('exit-mode-btn');
         const newKeyModal = document.getElementById('new-key-modal');
 
@@ -479,13 +481,15 @@
             const inShop = state.inShop;
 
             allViews.forEach(v => v.classList.add('hidden'));
-            
+
             controlsContainer.classList.remove('hidden');
             dmToolsDropdown.classList.add('hidden');
 
+            dmToolsBtn.removeEventListener('click', toggleDmTools);
+            logoutBtn.removeEventListener('click', logout);
+
             if (inShop) {
                 dmToolsBtn.classList.add('hidden');
-                dmToolsBtn.onclick = null;
                 exitModeBtn.classList.remove('hidden');
                 toolbarTitle.classList.remove('hidden');
                 toolbarTitle.textContent = state.isDM ? '> DM Mode' : '> Player Mode';
@@ -493,16 +497,17 @@
                 exitModeBtn.classList.add('hidden');
                 toolbarTitle.classList.add('hidden');
                 dmToolsBtn.classList.remove('hidden');
-                dmToolsBtn.onclick = null;
-                if (loggedIn) {
-                    dmToolsBtn.textContent = "Logout";
-                    dmToolsBtn.onclick = logout;
-                } else {
-                    dmToolsBtn.textContent = "DM Tools";
-                    dmToolsBtn.onclick = toggleDmTools;
-                }
+                dmToolsBtn.textContent = "DM Tools";
+                dmToolsBtn.addEventListener('click', toggleDmTools);
             }
-            
+
+            if (loggedIn) {
+                logoutBtn.classList.remove('hidden');
+                logoutBtn.addEventListener('click', logout);
+            } else {
+                logoutBtn.classList.add('hidden');
+            }
+
             if (!loggedIn) {
                 authView.classList.remove('hidden');
             } else if (!inShop) {


### PR DESCRIPTION
## Summary
- Always display the DM Tools dropdown, regardless of login state
- Add a dedicated logout option inside DM Tools
- Register DM Tools and logout handlers during each render

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_689e41777974832a8e348a5df51cdc20