### PR TITLE
Prioritize shop state over auth for DM view

### DIFF
--- a/index.html
+++ b/index.html
@@ -503,17 +503,19 @@
                 }
             }
             
-            if (!loggedIn) {
-                authView.classList.remove('hidden');
-            } else if (!inShop) {
+            if (inShop) {
+                if (state.isDM) {
+                    dmView.classList.remove('hidden');
+                    renderDMView();
+                } else {
+                    playerView.classList.remove('hidden');
+                    renderPlayerView();
+                }
+            } else if (loggedIn) {
                 characterHubView.classList.remove('hidden');
                 renderCharacterHub();
-            } else if (state.isDM) {
-                dmView.classList.remove('hidden');
-                renderDMView();
             } else {
-                playerView.classList.remove('hidden');
-                renderPlayerView();
+                authView.classList.remove('hidden');
             }
         }
 


### PR DESCRIPTION
## Summary
- Ensure the app renders DM or player views when already in a shop, regardless of login
- Fall back to character hub or auth only when not in a shop

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e41765108832a9668ef63ccddabcb