### PR TITLE
Load character sheet from JSON file

### DIFF
--- a/character.html
+++ b/character.html
@@ -97,28 +97,9 @@
       <h1 class="text-2xl text-header">Character Sheet</h1>
       <button id="logout-btn" class="btn-secondary">Logout</button>
     </div>
-    <main id="sheet-container" class="space-y-6"></main>
+    <main id="sheet-container" class="space-y-6 py-8 my-8 max-w-4xl mx-auto"></main>
 
-    <script type="module">
-      import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
-      import {
-        getFirestore,
-        doc,
-        getDoc,
-      } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
-
-      const firebaseConfig = {
-        apiKey: "AIzaSyCwFPAjqfOC1cqTjbpqTu-xk7DrK44NPvU",
-        authDomain: "dnd-shop-app-c4f86.firebaseapp.com",
-        projectId: "dnd-shop-app-c4f86",
-        storageBucket: "dnd-shop-app-c4f86.firebasestorage.app",
-        messagingSenderId: "42798381853",
-        appId: "1:42798381853:web:856301cb1ca5ce5ce071da",
-      };
-
-      const app = initializeApp(firebaseConfig);
-      const db = getFirestore(app);
-
+    <script>
       document.getElementById("back-btn").addEventListener("click", () => {
         window.location.href = "index.html";
       });
@@ -163,30 +144,29 @@
               `<div>${n}: <span class="text-item-name">${o.bonus ?? "-"}</span>${o.prof ? " *" : ""}</div>`,
           )
           .join("");
-        const inv = (data.inventory || [])
-          .map((i) => `<li><span class="text-item-name">${i.name}</span></li>`)
+        const attacks = (data.attacks || [])
+          .map(
+            (a) =>
+              `<li><span class="text-item-name">${a.name}</span> ${a.atkBonus || ""} ${a.damage || ""}</li>`,
+          )
           .join("");
-        const equipmentList = data.equipment?.list
-          ? `<p class="mt-2 whitespace-pre-line">${data.equipment.list}</p>`
-          : "";
         const money = data.equipment?.money
           ? `CP:${data.equipment.money.cp || 0} SP:${data.equipment.money.sp || 0} EP:${data.equipment.money.ep || 0} GP:${data.equipment.money.gp || 0} PP:${data.equipment.money.pp || 0}`
           : "";
 
         const imgSrc =
-          data.image || "https://via.placeholder.com/300x300?text=Character";
+          data.avatarUrl || "https://i.imgur.com/zLRhJXx.png";
 
         document.getElementById("sheet-container").innerHTML = `
                 <div class="cli-window">
-                    <h2 class="text-2xl text-header mb-1 text-center">${data.name || "Unknown Adventurer"}</h2>
+                    <h2 class="text-2xl text-header mb-1 text-center">${data.charname || "Unknown Adventurer"}</h2>
                     <p class="text-center text-dim mb-4">
                         ${[data.classlevel, data.race, data.alignment].filter(Boolean).join(" | ")}
                     </p>
                     <div class="flex flex-col md:flex-row items-center md:items-start gap-4">
-                        <img src="${imgSrc}" alt="${data.name || "Character"} image" class="w-full md:w-1/2 max-w-xs object-cover border border-white/50" />
-                        <div class="grid grid-cols-2 gap-2 w-full md:w-1/2">${abilities}</div>
+                        <img src="${imgSrc}" alt="${data.charname || "Character"} image" class="w-full md:w-1/2 max-w-xs aspect-square object-cover border border-white/50 max-h-60 md:max-h-80" />
+                        <div class="grid grid-cols-2 sm:grid-cols-3 gap-2 w-full md:w-1/2">${abilities}</div>
                     </div>
-                    ${data.gold ? `<p class="text-price text-center mt-4">${data.gold} GP</p>` : ""}
                 </div>
                 <div class="cli-window">
                     <h3 class="text-2xl text-header mb-4">> Combat</h3>
@@ -198,18 +178,31 @@
                     </div>
                 </div>
                 <details class="cli-window">
-                    <summary class="text-2xl text-header cursor-pointer">> Skills & Saves</summary>
-                    <div class="mt-4 grid grid-cols-1 md:grid-cols-2 gap-2">
+                    <summary class="text-2xl text-header cursor-pointer">> Saving Throws</summary>
+                    <div class="mt-4 space-y-1">
                         ${saves || '<p class="text-dim">No save data.</p>'}
-                        ${skills || ""}
                     </div>
+                </details>
+                <details class="cli-window">
+                    <summary class="text-2xl text-header cursor-pointer">> Skills</summary>
+                    <div class="mt-4 space-y-1">
+                        ${skills || '<p class="text-dim">No skill data.</p>'}
+                        ${data.passiveperception ? `<div>Passive Perception: <span class="text-item-name">${data.passiveperception}</span></div>` : ""}
+                        ${data.otherprofs ? `<div>Other Profs: <span class="text-item-name">${data.otherprofs}</span></div>` : ""}
+                    </div>
+                </details>
+                <details class="cli-window">
+                    <summary class="text-2xl text-header cursor-pointer">> Attacks</summary>
+                    <ul class="mt-4 list-disc pl-5">
+                        ${attacks || '<li class="text-dim">No attacks.</li>'}
+                    </ul>
+                    ${data.attacksNotes ? `<p class="mt-2">${data.attacksNotes}</p>` : ""}
                 </details>
                 <details class="cli-window">
                     <summary class="text-2xl text-header cursor-pointer">> Equipment</summary>
                     <div class="mt-4">
                         ${money ? `<p>> ${money}</p>` : ""}
-                        ${inv ? `<ul class="list-disc pl-5 mt-2">${inv}</ul>` : '<p class="text-dim mt-2">No equipment.</p>'}
-                        ${equipmentList}
+                        ${data.equipment?.list ? `<p class="mt-2 whitespace-pre-line">${data.equipment.list}</p>` : ''}
                     </div>
                 </details>
                 <details class="cli-window">
@@ -226,15 +219,14 @@
       }
 
       async function loadCharacter() {
-        const key = localStorage.getItem("dndShopCharacterKey");
-        if (!key) {
-          window.location.href = "index.html";
-          return;
-        }
-        const docSnap = await getDoc(doc(db, "characters", key));
-        if (docSnap.exists()) {
-          renderCharacterSheet(docSnap.data());
-        } else {
+        const params = new URLSearchParams(window.location.search);
+        const key = params.get("char") || "sample-character";
+        try {
+          const res = await fetch(`${key}.json`);
+          if (!res.ok) throw new Error("Character not found");
+          const data = await res.json();
+          renderCharacterSheet(data);
+        } catch (e) {
           document.getElementById("sheet-container").innerHTML =
             '<div class="cli-window text-center"><p class="text-header">Character not found.</p></div>';
         }

--- a/index.html
+++ b/index.html
@@ -63,15 +63,16 @@ z<!DOCTYPE html>
             text-transform: uppercase;
         }
         .input-field:focus, .select-field:focus { outline: none; box-shadow: 0 0 8px #ffffff; }
-        .ascii-title {
-            font-family: monospace; 
-            white-space: pre;
-            text-align: center;
-            font-size: clamp(0.8rem, 4vw, 1.5rem);
-            margin-bottom: 1rem;
-            color: var(--color-header);
-            text-shadow: var(--shadow-glow) var(--color-header);
-        }
+            .ascii-title {
+                font-family: monospace;
+                white-space: pre;
+                text-align: center;
+                font-size: clamp(0.8rem, 2.5vw, 1.5rem);
+                line-height: 1;
+                margin-bottom: 1rem;
+                color: var(--color-header);
+                text-shadow: var(--shadow-glow) var(--color-header);
+            }
         .text-header { color: var(--color-header); text-shadow: var(--shadow-glow) var(--color-header); }
         .text-item-name { color: var(--color-accent); }
         .text-price { color: var(--color-price); font-weight: bold; }

--- a/sample-character.json
+++ b/sample-character.json
@@ -1,16 +1,76 @@
 {
-  "name": "Sigon Talandriel",
-  "classlevel": "Wizard 2",
-  "race": "High Elf",
-  "alignment": "Chaotic Neutral",
-  "gold": 15,
-  "image": "https://example.com/portrait.jpg",
+  "charname": "Name",
+  "avatarUrl": "https://i.imgur.com/zLRhJXx.png",
+  "classlevel": "Class 0",
+  "background": "Background",
+  "playername": "Player Name",
+  "race": "Race",
+  "alignment": "Alignment",
+  "experiencepoints": 0,
+
+  "inspiration": false,
+  "proficiencybonus": "+0",
+
   "abilities": {
-    "Strength": { "score": 13, "mod": 1 },
-    "Dexterity": { "score": 15, "mod": 2 },
-    "Constitution": { "score": 12, "mod": 1 },
-    "Intelligence": { "score": 15, "mod": 2 },
-    "Wisdom": { "score": 12, "mod": 1 },
-    "Charisma": { "score": 11, "mod": 0 }
-  }
+    "Strength": { "score": 0, "mod": 0, "save": "+0", "saveProf": false },
+    "Dexterity": { "score": 0, "mod": 0, "save": "+0", "saveProf": false },
+    "Constitution": { "score": 0, "mod": 0, "save": "+0", "saveProf": false },
+    "Wisdom": { "score": 0, "mod": 0, "save": "+0", "saveProf": false },
+    "Intelligence": { "score": 0, "mod": 0, "save": "+0", "saveProf": false },
+    "Charisma": { "score": 0, "mod": 0, "save": "+0", "saveProf": false }
+  },
+
+  "skills": {
+    "Acrobatics": { "bonus": "+0", "prof": false },
+    "Animal Handling": { "bonus": "+0", "prof": false },
+    "Arcana": { "bonus": "+0", "prof": false },
+    "Athletics": { "bonus": "+0", "prof": false },
+    "Deception": { "bonus": "+0", "prof": false },
+    "History": { "bonus": "+0", "prof": false },
+    "Insight": { "bonus": "+0", "prof": false },
+    "Intimidation": { "bonus": "+0", "prof": false },
+    "Investigation": { "bonus": "+0", "prof": false },
+    "Medicine": { "bonus": "+0", "prof": false },
+    "Nature": { "bonus": "+0", "prof": false },
+    "Perception": { "bonus": "+0", "prof": false },
+    "Performance": { "bonus": "+0", "prof": false },
+    "Persuasion": { "bonus": "+0", "prof": false },
+    "Religion": { "bonus": "+0", "prof": false },
+    "Sleight of Hand": { "bonus": "+0", "prof": false },
+    "Stealth": { "bonus": "+0", "prof": false },
+    "Survival": { "bonus": "+0", "prof": false }
+  },
+
+  "passiveperception": 0,
+  "otherprofs": "Languages/Tools",
+
+  "combat": {
+    "ac": 0,
+    "initiative": "+0",
+    "speed": 0,
+    "hp": { "max": 0, "current": 0, "temp": 0 },
+    "hitdice": { "total": "0d0", "remaining": "0d0" },
+    "deathSaves": { "successes": 0, "failures": 0 }
+  },
+
+  "attacks": [
+    { "name": "Attack 1", "atkBonus": "+0", "damage": "0" },
+    { "name": "Attack 2", "atkBonus": "+0", "damage": "0" },
+    { "name": "Attack 3", "atkBonus": "+0", "damage": "0" }
+  ],
+  "attacksNotes": "",
+
+  "equipment": {
+    "money": { "cp": 0, "sp": 0, "ep": 0, "gp": 0, "pp": 0 },
+    "list": "Item list"
+  },
+
+  "flavor": {
+    "personality": "Personality",
+    "ideals": "Ideals",
+    "bonds": "Bonds",
+    "flaws": "Flaws"
+  },
+
+  "features": "Features & Traits"
 }


### PR DESCRIPTION
## Summary
- Refine character sheet layout for mobile with extra spacing and responsive ability grid
- Separate saving throws and skills into individual dropdowns
- Adjust ASCII title sizing and update placeholder character image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e87c74e34832ab89f7cf8ed68b49f