### PR TITLE
Add inventory item details and modernize styling

### DIFF
--- a/character.html
+++ b/character.html
@@ -14,11 +14,11 @@
     <style>
       :root {
         --color-text: #e0e0e0;
-        --color-header: #00ff00;
-        --color-accent: #00ffff;
+        --color-header: #33ff99;
+        --color-accent: #33ffff;
         --color-price: #ffd700;
-        --color-dim: #a0a0a0;
-        --color-border: #cccccc;
+        --color-dim: #bbbbbb;
+        --color-border: #555555;
         --shadow-glow: 0 0 7px;
       }
       html {
@@ -26,18 +26,19 @@
       }
       body {
         font-family: "VT323", monospace;
-        background-color: #000000;
+        background-color: #111111;
         color: var(--color-text);
-        font-size: 20px;
+        font-size: 22px;
         line-height: 1.6;
         overflow-x: hidden;
         padding-top: 5rem;
       }
       .cli-window {
-        border: 2px solid var(--color-border);
+        border: 1px solid var(--color-border);
+        border-radius: 0.375rem;
         padding: 1rem;
-        background-color: rgba(10, 10, 10, 0.4);
-        box-shadow: 0 0 10px rgba(204, 204, 204, 0.3);
+        background-color: rgba(20, 20, 20, 0.9);
+        box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
         opacity: 0;
         transform: translateY(20px);
         animation: fadeIn 0.5s forwards;
@@ -56,6 +57,7 @@
         color: #000000;
         cursor: pointer;
         border: none;
+        border-radius: 0.25rem;
         transition: all 0.2s ease-in-out;
       }
       .btn:hover:not(:disabled) {
@@ -67,6 +69,7 @@
         background-color: transparent;
         color: #ffffff;
         border: 1px solid #ffffff;
+        border-radius: 0.25rem;
       }
       .btn-secondary:hover {
         background-color: #ffffff;
@@ -115,22 +118,14 @@
             ? `+${obj.mod}`
             : (obj.mod ?? "");
         return `<div class="flex flex-col items-center border border-white/50 p-1">
-                        <div class="text-xs text-item-name">${name.slice(0, 3).toUpperCase()}</div>
+                        <div class="text-sm text-item-name">${name.slice(0, 3).toUpperCase()}</div>
                         <div class="text-xl">${obj.score ?? "-"}</div>
                         <div class="text-dim text-sm">${mod ?? ""}</div>
                     </div>`;
       }
-
-      function statBox(label, value) {
-        return `<div class="flex flex-col items-center border border-white/50 p-1">
-                    <div class="text-xs text-item-name">${label}</div>
-                    <div class="text-xl">${value ?? "-"}</div>
-                </div>`;
-      }
-
       function saveBox(name, obj = {}) {
         return `<div class="flex flex-col items-center border border-white/50 p-1">
-                    <div class="text-xs text-item-name">${name.slice(0,3).toUpperCase()}</div>
+                    <div class="text-sm text-item-name">${name.slice(0,3).toUpperCase()}</div>
                     <div class="text-xl">${obj.save ?? "-"}</div>
                     <div class="text-dim text-sm">${obj.saveProf ? "*" : ""}</div>
                 </div>`;
@@ -170,30 +165,23 @@
         const imgSrc =
           data.avatarUrl || "https://i.imgur.com/zLRhJXx.png";
         const hpValue = data.combat?.hp ? `${data.combat.hp.current ?? "-"}/${data.combat.hp.max ?? "-"}` : "-";
-        const statsRow = [
-          statBox('AC', data.combat?.ac),
-          statBox('INIT', data.combat?.initiative),
-          statBox('HP', hpValue),
-          statBox('SPD', data.combat?.speed)
-        ].join('');
+        const statsLine = `Armor Class: <span class="text-item-name">${data.combat?.ac ?? "-"}</span> | Initiative: <span class="text-item-name">${data.combat?.initiative ?? "-"}</span> | Hit Points: <span class="text-item-name">${hpValue}</span> | Speed: <span class="text-item-name">${data.combat?.speed ?? "-"}</span>`;
 
         document.getElementById("sheet-container").innerHTML = `
-                <div class="cli-window">
-                    <div class="flex items-center justify-center gap-6 mb-4">
-                        <div class="text-left">
+                <div class="cli-window space-y-4">
+                    <div class="flex flex-col md:flex-row md:items-center gap-4">
+                        <img src="${imgSrc}" alt="${data.charname || "Character"} image" class="w-full md:w-1/3 aspect-square object-cover border border-white/50 max-w-[12rem] md:max-w-[16rem] mx-auto md:mx-0" />
+                        <div class="flex-1 text-center md:text-left">
                             <h2 class="text-2xl text-header">${data.charname || "Unknown Adventurer"}</h2>
                             <p class="text-dim">${[data.classlevel, data.race, data.alignment].filter(Boolean).join(" | ")}</p>
+                            <p class="mt-2 text-2xl">${statsLine}</p>
                         </div>
-                        <div class="grid grid-cols-4 gap-2">${statsRow}</div>
                     </div>
-                    <div class="flex flex-col md:flex-row items-center md:items-start gap-4">
-                        <img src="${imgSrc}" alt="${data.charname || "Character"} image" class="w-full md:w-1/2 aspect-square object-cover border border-white/50 max-w-[15rem] max-h-[15rem] md:max-w-[20rem] md:max-h-[20rem]" />
-                        <div class="grid grid-cols-3 gap-2 w-full md:w-1/2">${abilities}</div>
-     </div>
+                    <div class="grid grid-cols-3 sm:grid-cols-6 gap-2">${abilities}</div>
                 </div>
                 <details class="cli-window">
                     <summary class="text-2xl text-header cursor-pointer">> Saving Throws</summary>
-                    <div class="mt-4"><div class="grid grid-cols-6 gap-2">${saveBoxes}</div></div>
+                    <div class="mt-4"><div class="grid grid-cols-3 sm:grid-cols-6 gap-2">${saveBoxes}</div></div>
                 </details>
                 <details class="cli-window">
                     <summary class="text-2xl text-header cursor-pointer">> Skills</summary>

--- a/index.html
+++ b/index.html
@@ -12,17 +12,17 @@
     <style>
         :root {
             --color-text: #E0E0E0;
-            --color-header: #00FF00; /* Bright Green */
-            --color-accent: #00FFFF; /* Cyan */
+            --color-header: #33FF99; /* Softer Green */
+            --color-accent: #33FFFF; /* Soft Cyan */
             --color-price: #FFD700;  /* Gold */
-            --color-dim: #a0a0a0;
-            --color-border: #cccccc;
+            --color-dim: #BBBBBB;
+            --color-border: #555555;
             --shadow-glow: 0 0 7px;
         }
         html { scroll-behavior: smooth; }
         body {
             font-family: 'VT323', monospace;
-            background-color: #000000;
+            background-color: #111111;
             color: var(--color-text);
             font-size: 20px;
             line-height: 1.6;
@@ -30,10 +30,11 @@
             padding-top: 5rem; /* Space for the fixed navbar */
         }
         .cli-window {
-            border: 2px solid var(--color-border);
+            border: 1px solid var(--color-border);
+            border-radius: 0.375rem;
             padding: 1rem;
-            background-color: rgba(10, 10, 10, 0.4);
-            box-shadow: 0 0 10px rgba(204, 204, 204, 0.3);
+            background-color: rgba(20, 20, 20, 0.9);
+            box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
             opacity: 0;
             transform: translateY(20px);
             animation: fadeIn 0.5s forwards;
@@ -48,22 +49,24 @@
             text-shadow: none;
             cursor: pointer;
             border: none;
+            border-radius: 0.25rem;
             transition: all 0.2s ease-in-out;
         }
         .btn:hover:not(:disabled) { background-color: #000000; color: #ffffff; box-shadow: 0 0 5px #ffffff; }
-        .btn-secondary { background-color: transparent; color: #ffffff; border: 1px solid #ffffff; }
+        .btn-secondary { background-color: transparent; color: #ffffff; border: 1px solid #ffffff; border-radius: 0.25rem; }
         .btn-secondary:hover { background-color: #ffffff; color: #000000; }
         .btn:disabled { background-color: #333; color: #888; cursor: not-allowed; opacity: 0.7; }
         .input-field, .select-field {
-            background-color: #111;
-            border: 1px solid #ffffff;
+            background-color: #1a1a1a;
+            border: 1px solid var(--color-border);
             color: #ffffff;
             padding: 0.75rem;
             width: 100%;
             font-family: 'VT323', monospace;
             text-transform: uppercase;
+            border-radius: 0.25rem;
         }
-        .input-field:focus, .select-field:focus { outline: none; box-shadow: 0 0 8px #ffffff; }
+        .input-field:focus, .select-field:focus { outline: none; box-shadow: 0 0 8px var(--color-accent); }
             .ascii-title {
                 font-family: monospace;
                 white-space: pre;
@@ -161,6 +164,15 @@
         </div>
     </div>
 
+    <!-- Inventory Modal -->
+    <div id="inventory-modal" class="hidden fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-[100] p-4">
+        <div class="cli-window w-full max-w-md text-center">
+            <button id="inventory-modal-close" class="subview-exit-btn">ⓧ</button>
+            <h2 class="text-2xl font-bold mb-4 text-header">> Edit Inventory</h2>
+            <div id="inventory-list" class="space-y-2 max-h-72 overflow-y-auto"></div>
+        </div>
+    </div>
+
     <!-- Character Keys Modal -->
     <div id="keys-modal" class="hidden fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-[100] p-4">
         <div class="cli-window w-full max-w-md text-center">
@@ -210,6 +222,7 @@
             shopId: null,
             shopData: null,
             activeShops: [],
+            dmShops: [],
         };
 
         // DOM Elements
@@ -227,6 +240,7 @@
         const exitModeBtn = document.getElementById('exit-mode-btn');
         const newKeyModal = document.getElementById('new-key-modal');
         const keysModal = document.getElementById('keys-modal');
+        const inventoryModal = document.getElementById('inventory-modal');
 
         // --- Initialization ---
         function main() {
@@ -250,6 +264,11 @@
                     keysModal.classList.add('hidden');
                 }
             });
+            inventoryModal.addEventListener('click', (e) => {
+                if (e.target === inventoryModal || e.target.id === 'inventory-modal-close') {
+                    closeInventoryModal();
+                }
+            });
 
             // Check for saved key
             const savedKey = localStorage.getItem('dndShopCharacterKey');
@@ -265,21 +284,42 @@
                 acc[item.name] = (acc[item.name] || 0) + 1;
                 return acc;
             }, {});
-            const itemName = prompt('Enter the item name to remove:');
-            if (!itemName) return;
-            const available = summary[itemName];
-            if (!available) { alert('Item not found.'); return; }
-            const qty = parseInt(prompt(`Remove how many? (1-${available})`), 10);
+            const list = document.getElementById('inventory-list');
+            list.innerHTML = Object.keys(summary).length === 0
+                ? '<p class="text-dim">Empty.</p>'
+                : Object.entries(summary).map(([name, count]) => `
+                    <div class="flex justify-between items-center">
+                        <span><span class="text-item-name">${name}</span> <span class="text-dim">(x${count})</span></span>
+                        <div class="flex items-center gap-2">
+                            <input type="number" min="1" max="${count}" value="1" class="input-field w-16" data-name="${name}">
+                            <button class="text-red-500 hover:text-red-400 inv-remove-btn" data-name="${name}">[X]</button>
+                        </div>
+                    </div>
+                `).join('');
+            inventoryModal.classList.remove('hidden');
+            document.querySelectorAll('.inv-remove-btn').forEach(btn => btn.addEventListener('click', handlePlayerInventoryRemove));
+        }
+
+        function handlePlayerInventoryRemove(e) {
+            const name = e.target.dataset.name;
+            const input = document.querySelector(`input[data-name="${name}"]`);
+            const qty = parseInt(input.value, 10);
+            const available = state.playerData.inventory.filter(it => it.name === name).length;
             if (!qty || qty <= 0 || qty > available) return;
-            if (!confirm(`Remove ${qty} ${itemName}? This cannot be undone.`)) return;
+            if (!confirm(`Remove ${qty} ${name}?`)) return;
             let remaining = qty;
             const newInv = state.playerData.inventory.filter(it => {
-                if (it.name === itemName && remaining > 0) { remaining--; return false; }
+                if (it.name === name && remaining > 0) { remaining--; return false; }
                 return true;
             });
             state.playerData.inventory = newInv;
             updateDoc(doc(db, 'characters', state.characterKey), { inventory: newInv });
+            closeInventoryModal();
             renderCharacterHub();
+        }
+
+        function closeInventoryModal() {
+            inventoryModal.classList.add('hidden');
         }
 
         // --- Auth & Character Functions ---
@@ -336,12 +376,21 @@
         }
 
         let activeShopsUnsubscribe = null;
+        let dmShopsUnsubscribe = null;
         function listenToActiveShops() {
             if (activeShopsUnsubscribe) activeShopsUnsubscribe();
             const q = query(collection(db, 'shops'), where('active', '==', true));
             activeShopsUnsubscribe = onSnapshot(q, (snapshot) => {
                 state.activeShops = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
                 if (!state.inShop && !state.isDM) render();
+            });
+        }
+
+        function listenToDMShops() {
+            if (dmShopsUnsubscribe) dmShopsUnsubscribe();
+            dmShopsUnsubscribe = onSnapshot(collection(db, 'shops'), (snapshot) => {
+                state.dmShops = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+                if (state.isDM && !state.inShop) render();
             });
         }
 
@@ -359,6 +408,7 @@
             state.inShop = false;
             state.shopId = null;
             state.shopData = null;
+            listenToDMShops();
             render();
         }
 
@@ -417,10 +467,12 @@
 
         function exitCurrentMode() {
             if (shopUnsubscribe) { shopUnsubscribe(); shopUnsubscribe = null; }
+            if (dmShopsUnsubscribe) { dmShopsUnsubscribe(); dmShopsUnsubscribe = null; }
             state.isDM = false;
             state.inShop = false;
             state.shopId = null;
             state.shopData = null;
+            state.dmShops = [];
             render();
         }
 
@@ -482,6 +534,7 @@
 
             const finalInventory = randomInventory.map(item => ({
                 ...item,
+                details: item.details || '',
                 quantity: Math.floor(Math.random() * 5) + 1,
                 id: `item-${Math.random().toString(36).substr(2, 9)}`
             }));
@@ -647,16 +700,14 @@
                     </div>
                 </div>
                 <div class="mt-8 cli-window max-w-md mx-auto">
-                    <h2 class="text-2xl mb-4 text-header">> Active Shops</h2>
-                    ${state.activeShops.length === 0
-                        ? '<p class="text-dim">No active shops.</p>'
-                        : state.activeShops.map(s => `
-                            <div class="flex justify-between items-center mb-2">
-                                <span><span class="text-item-name">${s.shopName || s.shopType}</span></span>
-                                <div class="flex gap-2">
-                                    <button class="btn dm-enter-shop-btn" data-shop-id="${s.id}">Open</button>
-                                    <button class="btn btn-secondary dm-delete-shop-btn" data-shop-id="${s.id}">Delete</button>
-                                </div>
+                    <h2 class="text-2xl mb-4 text-header">> Your Shops</h2>
+                    ${state.dmShops.length === 0
+                        ? '<p class="text-dim">No shops.</p>'
+                        : state.dmShops.map(s => `
+                            <div class="flex items-center mb-2 gap-2">
+                                <button class="btn flex-1 text-left dm-enter-shop-btn" data-shop-id="${s.id}">${s.shopName || s.shopType}</button>
+                                <input type="checkbox" class="dm-active-checkbox" data-shop-id="${s.id}" ${s.active ? 'checked' : ''}>
+                                <button class="text-red-500 hover:text-red-400 dm-delete-shop-btn" data-shop-id="${s.id}">X</button>
                             </div>
                         `).join('')}
                 </div>
@@ -667,14 +718,20 @@
                 btn.addEventListener('click', e => joinShop(e.target.dataset.shopId));
             });
             document.querySelectorAll('.dm-delete-shop-btn').forEach(btn => btn.addEventListener('click', handleDMDeleteShop));
+            document.querySelectorAll('.dm-active-checkbox').forEach(cb => cb.addEventListener('change', handleDMActiveChange));
         }
 
         async function handleDMDeleteShop(e) {
             const shopId = e.target.dataset.shopId;
             if (!confirm('Delete this shop? This cannot be undone.')) return;
             await deleteDoc(doc(db, 'shops', shopId));
-            state.activeShops = state.activeShops.filter(s => s.id !== shopId);
+            state.dmShops = state.dmShops.filter(s => s.id !== shopId);
             renderDMHub();
+        }
+
+        async function handleDMActiveChange(e) {
+            const shopId = e.target.dataset.shopId;
+            await updateDoc(doc(db, 'shops', shopId), { active: e.target.checked });
         }
         
         function getModifiedPrice(basePrice) {
@@ -685,8 +742,8 @@
 
         function renderDMView() {
             const { shopkeeper, inventory, carts, shopType, priceModifier, shopName } = state.shopData;
-            dmView.innerHTML = `<div class="grid grid-cols-1 lg:grid-cols-3 gap-6 text-lg">
-                <div class="lg:col-span-1 flex flex-col gap-6">
+            dmView.innerHTML = `<div class="grid grid-cols-1 md:grid-cols-3 gap-6 text-lg">
+                <div class="md:col-span-1 flex flex-col gap-6">
                     <div class="cli-window">
                         <h2 class="text-2xl mb-4 text-header">> DM Controls</h2>
                         <p class="mb-1">> Shop: <span class="text-item-name">${shopName}</span></p>
@@ -707,13 +764,14 @@
                     </div>
                     <div class="cli-window"><h3 class="text-2xl mb-4 text-header">> Shopkeeper</h3><p>> Name: <span class="text-item-name">${shopkeeper.name}</span></p><p class="text-dim">> Personality: ${shopkeeper.description||'...'}</p><div class="flex items-center gap-2 mt-2"><p class="whitespace-nowrap">> Gold:</p><input type="number" id="shop-gold-input" value="${shopkeeper.gold}" class="input-field text-price"></div></div>
                 </div>
-                <div class="lg:col-span-1 flex flex-col gap-6">
+                <div class="md:col-span-1 flex flex-col gap-6">
                     <div class="cli-window">
                         <h3 class="text-2xl mb-4 text-header">> Shop Inventory</h3>
-                        <div id="dm-inventory-list" class="space-y-4">${inventory.map((item,index)=>`<div class="item-card border border-white/50 p-3 space-y-2" data-index="${index}"><div class="flex justify-between items-center"><span class="text-item-name">${item.name}</span><button class="text-red-500 hover:text-red-400 dm-remove-item-btn" data-index="${index}">[X]</button></div><div class="flex items-center gap-2"><label class="text-dim">Qty:</label><input type="number" min="0" class="input-field dm-qty-input w-16" data-index="${index}" value="${item.quantity}"><label class="text-dim">Price:</label><input type="number" min="0" step="0.01" class="input-field dm-price-input w-24" data-index="${index}" value="${item.price}"></div></div>`).join('')}</div>
+                        <div id="dm-inventory-list" class="space-y-4">${inventory.map((item,index)=>`<div class="item-card border border-white/50 p-3 space-y-2" data-index="${index}"><div class="flex justify-between items-center"><span class="text-item-name">${item.name}</span><button class="text-red-500 hover:text-red-400 dm-remove-item-btn" data-index="${index}">[X]</button></div><textarea class="input-field dm-details-input w-full" data-index="${index}" placeholder="Details">${item.details||''}</textarea><div class="flex items-center gap-2"><label class="text-dim">Qty:</label><input type="number" min="0" class="input-field dm-qty-input w-16" data-index="${index}" value="${item.quantity}"><label class="text-dim">Price:</label><input type="number" min="0" step="0.01" class="input-field dm-price-input w-24" data-index="${index}" value="${item.price}"></div></div>`).join('')}</div>
                         <div class="mt-4">
                             <h4 class="text-xl mb-2 text-header">> Add Custom Item</h4>
                             <input id="custom-item-name" class="input-field mb-2" placeholder="Item Name">
+                            <textarea id="custom-item-details" class="input-field mb-2" placeholder="Details"></textarea>
                             <div class="flex gap-2 mb-2">
                                 <input id="custom-item-price" type="number" class="input-field flex-1" placeholder="Price">
                                 <input id="custom-item-qty" type="number" class="input-field flex-1" placeholder="Qty">
@@ -722,7 +780,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="lg:col-span-1 flex flex-col gap-6">
+                <div class="md:col-span-1 flex flex-col gap-6">
                     <div class="cli-window"><h3 class="text-2xl mb-4 text-header">> Player Carts</h3><div id="player-carts-list" class="space-y-4">${Object.keys(carts || {}).length===0?'<p class="text-dim">No active carts.</p>':Object.entries(carts).map(([playerId,cartData])=>`<div><h4 class="text-xl text-header">${cartData.playerName}</h4>${cartData.items.length > 0 ? `<ul class="pl-4 list-disc list-inside">${cartData.items.map(item=>`<li><span class="text-item-name">${item.name}</span></li>`).join('')}</ul><p class="mt-2 text-right">> Cart Total: <span class="text-price">${cartData.items.reduce((sum,item)=>sum+getModifiedPrice(item.price),0)} GP</span></p><div class="grid grid-cols-2 gap-2 mt-3"><button class="btn checkout-btn" data-player-id="${playerId}">Checkout</button><button class="btn btn-secondary clear-cart-btn" data-player-id="${playerId}">Clear Cart</button></div>` : `<p class="text-dim">Cart is empty.</p><div class="mt-3"><button class="btn btn-secondary clear-cart-btn w-full" data-player-id="${playerId}">Remove Cart</button></div>`}</div>`).join('')}</div></div>
                 </div>
             </div>`;
@@ -734,13 +792,13 @@
             const { shopkeeper, inventory, carts, shopType, shopName } = state.shopData;
             const playerCart = carts[state.characterKey] || { items: [] };
             const cartTotal = playerCart.items.reduce((sum, item) => sum + getModifiedPrice(item.price), 0);
-            playerView.innerHTML = `<div class="grid grid-cols-1 lg:grid-cols-3 gap-6 text-lg">
-                <div class="lg:col-span-2">
+            playerView.innerHTML = `<div class="grid grid-cols-1 md:grid-cols-3 gap-6 text-lg">
+                <div class="md:col-span-2">
                     <div class="cli-window mb-6"><h1 class="text-3xl text-header">${shopName}</h1><p class="text-xl text-dim">(${shopType})</p><p class="text-xl">> Shopkeeper: <span class="text-item-name">${shopkeeper.name}</span></p><p class="text-xl text-dim">> ${shopkeeper.description||'...'}</p></div>
 
-                    <div class="cli-window"><h2 class="text-2xl mb-4 text-header">> Items for Sale</h2><div class="grid grid-cols-1 md:grid-cols-2 gap-4">${inventory.map(item=>`<div class="item-card ${item.quantity === 0 ? 'sold-out' : ''} border border-white/50 p-3 flex flex-col justify-between" data-item-id="${item.id}"><p class="text-xl"><span class="text-item-name">${item.name}</span> <span class="text-dim">(x${item.quantity})</span></p><p class="text-price">${item.quantity > 0 ? `${getModifiedPrice(item.price)} GP` : 'SOLD OUT'}</p><div class="mt-auto pt-2 flex justify-end items-center gap-2">${item.quantity > 0 ? `<button class="btn add-to-cart-btn" data-item-id="${item.id}">Add</button>`: ''}</div></div>`).join('')}</div></div>
+                    <div class="cli-window"><h2 class="text-2xl mb-4 text-header">> Items for Sale</h2><div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">${inventory.map(item=>`<div class="item-card ${item.quantity === 0 ? 'sold-out' : ''} border border-white/50 p-3 flex flex-col justify-between" data-item-id="${item.id}"><p class="text-xl"><span class="text-item-name">${item.name}</span> <span class="text-dim">(x${item.quantity})</span></p>${item.details?`<p class="text-sm text-dim">${item.details}</p>`:''}<p class="text-price">${item.quantity > 0 ? `${getModifiedPrice(item.price)} GP` : 'SOLD OUT'}</p><div class="mt-auto pt-2 flex justify-end items-center gap-2">${item.quantity > 0 ? `<button class="btn add-to-cart-btn" data-item-id="${item.id}">Add</button>`: ''}</div></div>`).join('')}</div></div>
                 </div>
-                <div class="lg:col-span-1">
+                <div class="md:col-span-1">
                     <div class="cli-window sticky top-24"><h2 class="text-2xl mb-4 text-header">> ${state.playerData.name}'s Purse</h2><p class="text-2xl text-price">${state.playerData.gold} GP</p><hr class="border-white/50 my-4"><h2 class="text-2xl mb-4 text-header">> Your Cart</h2><div id="player-cart-list" class="space-y-2 mb-4 min-h-[50px]">${playerCart.items.length===0?'<p class="text-dim">Your cart is empty.</p>':playerCart.items.map((item,index)=>`<div class="flex justify-between items-center"><span>- <span class="text-item-name">${item.name}</span></span><button class="text-red-500 hover:text-red-400 remove-from-cart-btn" data-index="${index}">[X]</button></div>`).join('')}</div><hr class="border-white/50 my-4"><p class="text-xl text-right">> Total: <span class="text-price">${cartTotal} GP</span></p></div>
                 </div>
             </div>`;
@@ -798,8 +856,8 @@
                     newInventory[invIndex] = { ...item, quantity: item.quantity - 1 };
 
                     const playerCart = shopData.carts[state.characterKey] || { playerName: state.playerData.name, items: [] };
-                    const { id, name, price } = item;
-                    const newCartItems = [...playerCart.items, { id, name, price }];
+                    const { id, name, price, details } = item;
+                    const newCartItems = [...playerCart.items, { id, name, price, details }];
 
                     transaction.update(shopRef, {
                         inventory: newInventory,
@@ -867,9 +925,9 @@
 
         function handleInventoryUpdate(e) {
             const index = parseInt(e.target.dataset.index, 10);
-            const field = e.target.classList.contains('dm-qty-input') ? 'quantity' : 'price';
-            let value = field === 'price' ? parseFloat(e.target.value) : parseInt(e.target.value, 10);
-            if (isNaN(value) || value < 0) return;
+            const field = e.target.classList.contains('dm-qty-input') ? 'quantity' : e.target.classList.contains('dm-price-input') ? 'price' : 'details';
+            let value = field === 'price' ? parseFloat(e.target.value) : field === 'quantity' ? parseInt(e.target.value, 10) : e.target.value;
+            if (field !== 'details' && (isNaN(value) || value < 0)) return;
             const newInventory = [...state.shopData.inventory];
             newInventory[index] = { ...newInventory[index], [field]: value };
             state.shopData.inventory = newInventory;
@@ -887,17 +945,20 @@
 
         function handleAddCustomItem() {
             const nameInput = document.getElementById('custom-item-name');
+            const detailsInput = document.getElementById('custom-item-details');
             const priceInput = document.getElementById('custom-item-price');
             const qtyInput = document.getElementById('custom-item-qty');
             const name = nameInput.value.trim();
+            const details = detailsInput.value.trim();
             const price = parseFloat(priceInput.value);
             const qty = parseInt(qtyInput.value, 10);
             if (!name || isNaN(price) || isNaN(qty) || qty < 0 || price < 0) return;
-            const newItem = { id: `item-${Math.random().toString(36).substr(2,9)}`, name, price, quantity: qty };
+            const newItem = { id: `item-${Math.random().toString(36).substr(2,9)}`, name, price, quantity: qty, details };
             const newInventory = [...state.shopData.inventory, newItem];
             state.shopData.inventory = newInventory;
             updateDoc(doc(db, 'shops', state.shopId), { inventory: newInventory });
             nameInput.value = '';
+            detailsInput.value = '';
             priceInput.value = '';
             qtyInput.value = '';
             renderDMView();
@@ -907,7 +968,7 @@
             document.getElementById('shop-gold-input')?.addEventListener('change', (e) => { const newGold = parseInt(e.target.value, 10); if (!isNaN(newGold)) updateDoc(doc(db, 'shops', state.shopId), { "shopkeeper.gold": newGold }); });
             document.querySelectorAll('.checkout-btn').forEach(btn => btn.addEventListener('click', handleCheckout));
             document.querySelectorAll('.clear-cart-btn').forEach(btn => btn.addEventListener('click', handleClearCart));
-            document.querySelectorAll('.dm-qty-input, .dm-price-input').forEach(input => input.addEventListener('change', handleInventoryUpdate));
+            document.querySelectorAll('.dm-qty-input, .dm-price-input, .dm-details-input').forEach(input => input.addEventListener('change', handleInventoryUpdate));
             document.querySelectorAll('.dm-remove-item-btn').forEach(btn => btn.addEventListener('click', handleRemoveInventoryItem));
             document.querySelectorAll('.price-mod-btn').forEach(btn => btn.addEventListener('click', (e) => { updateDoc(doc(db, 'shops', state.shopId), { priceModifier: parseInt(e.target.dataset.value, 10) }); }));
             document.getElementById('toggle-active-btn')?.addEventListener('click', () => { updateDoc(doc(db, 'shops', state.shopId), { active: !state.shopData.active }); });


### PR DESCRIPTION
## Summary
- Allow DMs to add and edit item details which are shown to players
- Improve mobile layout for shop pages and character sheet stats
- Soften CLI styling with rounded panels and deeper gray background
- Simplify DM hub shop list with mobile-friendly open, activate and delete controls
- Expand character sheet fonts and spell out combat stats on a single line

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689eb3b9f5ac832ab592fa073089ac73