### PR TITLE
feat: redesign character sheet layout

### DIFF
--- a/character.html
+++ b/character.html
@@ -122,96 +122,122 @@
                 </div>`;
       }
 
-      function renderCharacterSheet(data) {
-        const abilityOrder = [
-          "Strength",
-          "Dexterity",
-          "Constitution",
-          "Intelligence",
-          "Wisdom",
-          "Charisma",
-        ];
-        const abilities = abilityOrder
-          .map((n) => abilityBox(n, data.abilities?.[n] || {}))
-          .join("");
-        const saveBoxes = abilityOrder
-          .map((n) => saveBox(n, data.abilities?.[n] || {}))
-          .join("");
-        const skills = Object.entries(data.skills || {})
-          .map(
-            ([n, o]) =>
-              `<div>${n}: <span class="text-item-name">${o.bonus ?? "-"}</span>${o.prof ? " *" : ""}</div>`,
-          )
-          .join("");
-        const attacks = (data.attacks || [])
-          .map(
-            (a) =>
-              `<li><span class="text-item-name">${a.name}</span> ${a.atkBonus || ""} ${a.damage || ""}</li>`,
-          )
-          .join("");
-        const money = data.equipment?.money
-          ? `CP:${data.equipment.money.cp || 0} SP:${data.equipment.money.sp || 0} EP:${data.equipment.money.ep || 0} GP:${data.equipment.money.gp || 0} PP:${data.equipment.money.pp || 0}`
-          : "";
+        function renderCharacterSheet(data) {
+          const abilityOrder = [
+            "Strength",
+            "Dexterity",
+            "Constitution",
+            "Intelligence",
+            "Wisdom",
+            "Charisma",
+          ];
+          const abilities = abilityOrder
+            .map((n) => abilityBox(n, data.abilities?.[n] || {}))
+            .join("");
+          const saveBoxes = abilityOrder
+            .map((n) => saveBox(n, data.abilities?.[n] || {}))
+            .join("");
+          const skills = Object.entries(data.skills || {})
+            .map(
+              ([n, o]) =>
+                `<div>${n}: <span class="text-item-name">${o.bonus ?? "-"}</span>${o.prof ? " *" : ""}</div>`,
+            )
+            .join("");
+          const attacks = (data.attacks || [])
+            .map(
+              (a) =>
+                `<li><span class="text-item-name">${a.name}</span> ${a.atkBonus || ""} ${a.damage || ""}</li>`,
+            )
+            .join("");
+          const money = data.equipment?.money
+            ? `CP:${data.equipment.money.cp || 0} SP:${data.equipment.money.sp || 0} EP:${data.equipment.money.ep || 0} GP:${data.equipment.money.gp || 0} PP:${data.equipment.money.pp || 0}`
+            : "";
 
-        const imgSrc =
-          data.avatarUrl || "https://i.imgur.com/zLRhJXx.png";
-        const hpValue = data.combat?.hp ? `${data.combat.hp.current ?? "-"}/${data.combat.hp.max ?? "-"}` : "-";
-        const statsLine = `Armor Class: <span class="text-item-name">${data.combat?.ac ?? "-"}</span> | Initiative: <span class="text-item-name">${data.combat?.initiative ?? "-"}</span> | Hit Points: <span class="text-item-name">${hpValue}</span> | Speed: <span class="text-item-name">${data.combat?.speed ?? "-"}</span>`;
+          const imgSrc = data.avatarUrl || "https://i.imgur.com/zLRhJXx.png";
+          const hpValue = data.combat?.hp
+            ? `${data.combat.hp.current ?? "-"} / ${data.combat.hp.max ?? "-"}`
+            : "-";
 
-        document.getElementById("sheet-container").innerHTML = `
-                <section class="cli-window">
-                    <div class="flex flex-col md:flex-row md:items-center gap-4">
-                        <img src="${imgSrc}" alt="${data.charname || "Character"} image" class="w-full md:w-1/3 aspect-square object-cover border border-white/50 max-w-[12rem] md:max-w-[16rem] mx-auto md:mx-0" />
-                        <div class="flex-1 text-center md:text-left">
-                            <h2 class="text-2xl text-header">${data.charname || "Unknown Adventurer"}</h2>
-                            <p class="text-dim">${[data.classlevel, data.race, data.alignment].filter(Boolean).join(" | ")}</p>
-                            <p class="mt-2 text-2xl">${statsLine}</p>
-                        </div>
-                    </div>
-                </section>
-                <section class="cli-window">
-                    <h3 class="text-2xl text-header mb-2">> Abilities</h3>
+          document.getElementById("sheet-container").innerHTML = `
+          <div class="max-w-6xl mx-auto px-4">
+            <div class="flex items-center gap-2 text-sm text-header mb-4">
+              <span class="inline-block w-2 h-2 rounded-full bg-green-500 shadow-[0_0_8px_rgba(0,255,136,0.8)]"></span>
+              <span class="tracking-widest">charsheet$</span>
+              <span class="text-dim">cat ./dnd/character.json</span>
+            </div>
+            <div class="rounded-2xl border border-white/20 p-4 bg-black/40">
+              <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div class="flex justify-center md:justify-start">
+                  <img src="${imgSrc}" alt="${data.charname || "Character"} image" class="w-full max-w-xs aspect-square object-cover border border-white/50 rounded-lg" />
+                </div>
+                <div class="md:col-span-2 flex flex-col justify-center text-center md:text-left space-y-2">
+                  <h2 class="text-3xl text-header">${data.charname || "Unknown Adventurer"}</h2>
+                  <p class="text-dim">${[data.classlevel, data.race, data.alignment].filter(Boolean).join(" | ")}</p>
+                  <p>AC: <span class="text-item-name">${data.combat?.ac ?? "-"}</span> | Initiative: <span class="text-item-name">${data.combat?.initiative ?? "-"}</span> | HP: <span class="text-item-name">${hpValue}</span> | Speed: <span class="text-item-name">${data.combat?.speed ?? "-"}</span></p>
+                </div>
+              </div>
+              <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6">
+                <div class="space-y-4">
+                  <div class="border border-white/20 rounded-xl p-3">
+                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Attributes</h3>
                     <div class="grid grid-cols-3 sm:grid-cols-6 gap-2">${abilities}</div>
-                </section>
-                <details class="cli-window">
-                    <summary class="text-2xl text-header cursor-pointer">> Saving Throws</summary>
-                    <div class="mt-4"><div class="grid grid-cols-3 sm:grid-cols-6 gap-2">${saveBoxes}</div></div>
-                </details>
-                <details class="cli-window">
-                    <summary class="text-2xl text-header cursor-pointer">> Skills</summary>
-                    <div class="mt-4 space-y-1">
-                        ${skills || '<p class="text-dim">No skill data.</p>'}
-                        ${data.passiveperception ? `<div>Passive Perception: <span class="text-item-name">${data.passiveperception}</span></div>` : ""}
-                        ${data.otherprofs ? `<div>Other Profs: <span class="text-item-name">${data.otherprofs}</span></div>` : ""}
+                  </div>
+                  <div class="border border-white/20 rounded-xl p-3">
+                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Saving Throws</h3>
+                    <div class="grid grid-cols-3 sm:grid-cols-6 gap-2">${saveBoxes}</div>
+                  </div>
+                  <div class="border border-white/20 rounded-xl p-3">
+                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Skills</h3>
+                    <div class="space-y-1">
+                      ${skills || '<p class="text-dim">No skill data.</p>'}
+                      ${data.passiveperception ? `<p>Passive Perception: <span class="text-item-name">${data.passiveperception}</span></p>` : ""}
+                      ${data.otherprofs ? `<p>Other Profs: <span class="text-item-name">${data.otherprofs}</span></p>` : ""}
                     </div>
-                </details>
-                <details class="cli-window">
-
-                    <summary class="text-2xl text-header cursor-pointer">> Attacks</summary>
-                    <ul class="mt-4 list-disc pl-5">
-                        ${attacks || '<li class="text-dim">No attacks.</li>'}
-                    </ul>
+                  </div>
+                </div>
+                <div class="space-y-4">
+                  <div class="border border-white/20 rounded-xl p-3">
+                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Combat</h3>
+                    <p>Hit Dice: <span class="text-item-name">${data.combat?.hitdice?.remaining ?? "-"}</span></p>
+                    <p>Death Saves: <span class="text-item-name">${data.combat?.deathSaves ? `S:${data.combat.deathSaves.successes} F:${data.combat.deathSaves.failures}` : "-"}</span></p>
+                  </div>
+                  <div class="border border-white/20 rounded-xl p-3">
+                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Attacks &amp; Spellcasting</h3>
+                    <ul class="list-disc pl-4 space-y-1">${attacks || '<li class="text-dim">No attacks.</li>'}</ul>
                     ${data.attacksNotes ? `<p class="mt-2">${data.attacksNotes}</p>` : ""}
-                </details>
-                <details class="cli-window">
-                    <summary class="text-2xl text-header cursor-pointer">> Equipment</summary>
-                    <div class="mt-4">
-                        ${money ? `<p>> ${money}</p>` : ""}
-                        ${data.equipment?.list ? `<p class="mt-2 whitespace-pre-line">${data.equipment.list}</p>` : ''}
-                    </div>
-                </details>
-                <details class="cli-window">
-                    <summary class="text-2xl text-header cursor-pointer">> Notes</summary>
-                    <div class="mt-4 space-y-2">
-                        ${data.flavor?.personality ? `<p><span class="text-header">Personality:</span> ${data.flavor.personality}</p>` : ""}
-                        ${data.flavor?.ideals ? `<p><span class="text-header">Ideals:</span> ${data.flavor.ideals}</p>` : ""}
-                        ${data.flavor?.bonds ? `<p><span class="text-header">Bonds:</span> ${data.flavor.bonds}</p>` : ""}
-                        ${data.flavor?.flaws ? `<p><span class="text-header">Flaws:</span> ${data.flavor.flaws}</p>` : ""}
-                        ${data.features ? `<p><span class="text-header">Features:</span> ${data.features}</p>` : ""}
-                    </div>
-                </details>
-            `;
-      }
+                  </div>
+                  <div class="border border-white/20 rounded-xl p-3">
+                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Equipment</h3>
+                    ${money ? `<p>${money}</p>` : ""}
+                    ${data.equipment?.list ? `<p class="mt-2 whitespace-pre-line">${data.equipment.list}</p>` : ""}
+                  </div>
+                </div>
+                <div class="space-y-4">
+                  <div class="border border-white/20 rounded-xl p-3">
+                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Personality</h3>
+                    <p>${data.flavor?.personality || "-"}</p>
+                  </div>
+                  <div class="border border-white/20 rounded-xl p-3">
+                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Ideals</h3>
+                    <p>${data.flavor?.ideals || "-"}</p>
+                  </div>
+                  <div class="border border-white/20 rounded-xl p-3">
+                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Bonds</h3>
+                    <p>${data.flavor?.bonds || "-"}</p>
+                  </div>
+                  <div class="border border-white/20 rounded-xl p-3">
+                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Flaws</h3>
+                    <p>${data.flavor?.flaws || "-"}</p>
+                  </div>
+                  <div class="border border-white/20 rounded-xl p-3">
+                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Features &amp; Traits</h3>
+                    <p class="whitespace-pre-line">${data.features || "-"}</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>`;
+        }
 
       async function loadCharacter() {
         const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## Summary
- overhauled character sheet layout with terminal header and responsive 3-column grid
- added prominent avatar display and flavor sections

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fe62a57f8832aa6dd6d04974508c6