### PR TITLE
feat: collapsible sections for character sheet

### DIFF
--- a/character.html
+++ b/character.html
@@ -114,13 +114,27 @@
                         <div class="text-dim text-sm">${mod ?? ""}</div>
                     </div>`;
       }
-      function saveBox(name, obj = {}) {
+function saveBox(name, obj = {}) {
         return `<div class="flex flex-col items-center border border-white/50 p-1">
                     <div class="text-sm text-item-name">${name.slice(0,3).toUpperCase()}</div>
                     <div class="text-xl">${obj.save ?? "-"}</div>
                     <div class="text-dim text-sm">${obj.saveProf ? "*" : ""}</div>
                 </div>`;
-      }
+}
+
+function statBox(label, value) {
+  return `<div class="flex flex-col items-center border border-white/50 p-2 rounded">`
+        + `<div class="text-sm text-dim">${label}</div>`
+        + `<div class="text-xl text-item-name">${value ?? "-"}</div>`
+        + `</div>`;
+}
+
+function collapsibleSection(title, content, open = false) {
+  return `<details class="border border-white/20 rounded-xl" ${open ? "open" : ""}>`
+        + `<summary class="text-sm text-header py-2 px-3 uppercase tracking-widest cursor-pointer select-none">&gt; ${title}</summary>`
+        + `<div class="p-3 border-t border-white/20">${content}</div>`
+        + `</details>`;
+}
 
         function renderCharacterSheet(data) {
           const abilityOrder = [
@@ -153,10 +167,22 @@
             ? `CP:${data.equipment.money.cp || 0} SP:${data.equipment.money.sp || 0} EP:${data.equipment.money.ep || 0} GP:${data.equipment.money.gp || 0} PP:${data.equipment.money.pp || 0}`
             : "";
 
-          const imgSrc = data.avatarUrl || "https://i.imgur.com/zLRhJXx.png";
-          const hpValue = data.combat?.hp
-            ? `${data.combat.hp.current ?? "-"} / ${data.combat.hp.max ?? "-"}`
-            : "-";
+            const imgSrc = data.avatarUrl || "https://i.imgur.com/zLRhJXx.png";
+            const hpValue = data.combat?.hp
+              ? `${data.combat.hp.current ?? "-"} / ${data.combat.hp.max ?? "-"}`
+              : "-";
+
+            const abilitiesSection = collapsibleSection("Abilities", `<div class="grid grid-cols-3 sm:grid-cols-6 gap-2">${abilities}</div>`, true);
+            const savesSection = collapsibleSection("Saving Throws", `<div class="grid grid-cols-3 sm:grid-cols-6 gap-2">${saveBoxes}</div>`);
+            const skillsSection = collapsibleSection("Skills", `<div class="space-y-1">${skills || '<p class="text-dim">No skill data.</p>'}${data.passiveperception ? `<p>Passive Perception: <span class="text-item-name">${data.passiveperception}</span></p>` : ""}${data.otherprofs ? `<p>Other Profs: <span class="text-item-name">${data.otherprofs}</span></p>` : ""}</div>`);
+            const combatSection = collapsibleSection("Combat", `<p>Hit Dice: <span class="text-item-name">${data.combat?.hitdice?.remaining ?? "-"}</span></p><p>Death Saves: <span class="text-item-name">${data.combat?.deathSaves ? \`S:${data.combat.deathSaves.successes} F:${data.combat.deathSaves.failures}\` : "-"}</span></p>`);
+            const attacksSection = collapsibleSection("Attacks &amp; Spellcasting", `<ul class="list-disc pl-4 space-y-1">${attacks || '<li class="text-dim">No attacks.</li>'}</ul>${data.attacksNotes ? `<p class="mt-2">${data.attacksNotes}</p>` : ""}`);
+            const equipmentSection = collapsibleSection("Equipment", `${money ? `<p>${money}</p>` : ""}${data.equipment?.list ? `<p class="mt-2 whitespace-pre-line">${data.equipment.list}</p>` : ""}`);
+            const personalitySection = collapsibleSection("Personality", `<p>${data.flavor?.personality || "-"}</p>`);
+            const idealsSection = collapsibleSection("Ideals", `<p>${data.flavor?.ideals || "-"}</p>`);
+            const bondsSection = collapsibleSection("Bonds", `<p>${data.flavor?.bonds || "-"}</p>`);
+            const flawsSection = collapsibleSection("Flaws", `<p>${data.flavor?.flaws || "-"}</p>`);
+            const featuresSection = collapsibleSection("Features &amp; Traits", `<p class="whitespace-pre-line">${data.features || "-"}</p>`);
 
           document.getElementById("sheet-container").innerHTML = `
           <div class="max-w-6xl mx-auto px-4">
@@ -173,66 +199,31 @@
                 <div class="md:col-span-2 flex flex-col justify-center text-center md:text-left space-y-2">
                   <h2 class="text-3xl text-header">${data.charname || "Unknown Adventurer"}</h2>
                   <p class="text-dim">${[data.classlevel, data.race, data.alignment].filter(Boolean).join(" | ")}</p>
-                  <p>AC: <span class="text-item-name">${data.combat?.ac ?? "-"}</span> | Initiative: <span class="text-item-name">${data.combat?.initiative ?? "-"}</span> | HP: <span class="text-item-name">${hpValue}</span> | Speed: <span class="text-item-name">${data.combat?.speed ?? "-"}</span></p>
+                  <div class="grid grid-cols-2 sm:grid-cols-4 gap-2 mt-2">
+                    ${statBox("AC", data.combat?.ac)}
+                    ${statBox("Initiative", data.combat?.initiative)}
+                    ${statBox("HP", hpValue)}
+                    ${statBox("Speed", data.combat?.speed)}
+                  </div>
                 </div>
               </div>
               <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6">
                 <div class="space-y-4">
-                  <div class="border border-white/20 rounded-xl p-3">
-                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Attributes</h3>
-                    <div class="grid grid-cols-3 sm:grid-cols-6 gap-2">${abilities}</div>
-                  </div>
-                  <div class="border border-white/20 rounded-xl p-3">
-                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Saving Throws</h3>
-                    <div class="grid grid-cols-3 sm:grid-cols-6 gap-2">${saveBoxes}</div>
-                  </div>
-                  <div class="border border-white/20 rounded-xl p-3">
-                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Skills</h3>
-                    <div class="space-y-1">
-                      ${skills || '<p class="text-dim">No skill data.</p>'}
-                      ${data.passiveperception ? `<p>Passive Perception: <span class="text-item-name">${data.passiveperception}</span></p>` : ""}
-                      ${data.otherprofs ? `<p>Other Profs: <span class="text-item-name">${data.otherprofs}</span></p>` : ""}
-                    </div>
-                  </div>
+                  ${abilitiesSection}
+                  ${savesSection}
+                  ${skillsSection}
                 </div>
                 <div class="space-y-4">
-                  <div class="border border-white/20 rounded-xl p-3">
-                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Combat</h3>
-                    <p>Hit Dice: <span class="text-item-name">${data.combat?.hitdice?.remaining ?? "-"}</span></p>
-                    <p>Death Saves: <span class="text-item-name">${data.combat?.deathSaves ? `S:${data.combat.deathSaves.successes} F:${data.combat.deathSaves.failures}` : "-"}</span></p>
-                  </div>
-                  <div class="border border-white/20 rounded-xl p-3">
-                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Attacks &amp; Spellcasting</h3>
-                    <ul class="list-disc pl-4 space-y-1">${attacks || '<li class="text-dim">No attacks.</li>'}</ul>
-                    ${data.attacksNotes ? `<p class="mt-2">${data.attacksNotes}</p>` : ""}
-                  </div>
-                  <div class="border border-white/20 rounded-xl p-3">
-                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Equipment</h3>
-                    ${money ? `<p>${money}</p>` : ""}
-                    ${data.equipment?.list ? `<p class="mt-2 whitespace-pre-line">${data.equipment.list}</p>` : ""}
-                  </div>
+                  ${combatSection}
+                  ${attacksSection}
+                  ${equipmentSection}
                 </div>
                 <div class="space-y-4">
-                  <div class="border border-white/20 rounded-xl p-3">
-                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Personality</h3>
-                    <p>${data.flavor?.personality || "-"}</p>
-                  </div>
-                  <div class="border border-white/20 rounded-xl p-3">
-                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Ideals</h3>
-                    <p>${data.flavor?.ideals || "-"}</p>
-                  </div>
-                  <div class="border border-white/20 rounded-xl p-3">
-                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Bonds</h3>
-                    <p>${data.flavor?.bonds || "-"}</p>
-                  </div>
-                  <div class="border border-white/20 rounded-xl p-3">
-                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Flaws</h3>
-                    <p>${data.flavor?.flaws || "-"}</p>
-                  </div>
-                  <div class="border border-white/20 rounded-xl p-3">
-                    <h3 class="text-sm text-header mb-2 uppercase tracking-widest">&gt; Features &amp; Traits</h3>
-                    <p class="whitespace-pre-line">${data.features || "-"}</p>
-                  </div>
+                  ${personalitySection}
+                  ${idealsSection}
+                  ${bondsSection}
+                  ${flawsSection}
+                  ${featuresSection}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- make character sheet sections collapsible with Abilities open by default
- display AC, Initiative, HP, and Speed in tidy stat boxes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fea204308832ab8d8f939f93dc5f1