### PR TITLE
Add theme selector with multiple themes

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,18 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=VT323&family=Cormorant+Garamond:wght@400;700&family=Inter:wght@400;700&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
     <style>
-        :root {
+        html { scroll-behavior: smooth; }
+        body {
+            font-size: 20px;
+            line-height: 1.6;
+            overflow-x: hidden;
+            padding-top: 5rem; /* Space for the fixed navbar */
+            color: var(--color-text);
+            background-color: var(--color-bg);
+        }
+        body.cli-theme {
             --color-text: #E6E6E6;
             --color-header: #00FF88; /* Neon Green */
             --color-accent: #FFFFFF; /* White */
@@ -18,22 +27,63 @@
             --color-dim: #6B7280;
             --color-border: #333333;
             --shadow-glow: 0 0 8px;
-        }
-        html { scroll-behavior: smooth; }
-        body {
+            --color-bg: #0A0A0A;
+            --window-bg: rgba(20, 20, 20, 0.9);
+            --input-bg: #1a1a1a;
+            --input-text: #ffffff;
+            --btn-text: #000000;
             font-family: 'VT323', monospace;
-            background-color: #0A0A0A;
-            color: var(--color-text);
-            font-size: 20px;
-            line-height: 1.6;
-            overflow-x: hidden;
-            padding-top: 5rem; /* Space for the fixed navbar */
+        }
+        body.fantasy-theme {
+            --color-text: #3B2F2F;
+            --color-header: #8B4513;
+            --color-accent: #5C4033;
+            --color-price: #B8860B;
+            --color-dim: #7D6A55;
+            --color-border: #C0A080;
+            --shadow-glow: none;
+            --color-bg: #F5F5DC;
+            --window-bg: rgba(250, 240, 230, 0.9);
+            --input-bg: #FFF8DC;
+            --input-text: #3B2F2F;
+            --btn-text: #F5F5DC;
+            font-family: 'Cormorant Garamond', serif;
+        }
+        body.modern-theme {
+            --color-text: #1F2937;
+            --color-header: #111827;
+            --color-accent: #2563EB;
+            --color-price: #D97706;
+            --color-dim: #6B7280;
+            --color-border: #E5E7EB;
+            --shadow-glow: none;
+            --color-bg: #FFFFFF;
+            --window-bg: rgba(243, 244, 246, 0.9);
+            --input-bg: #F3F4F6;
+            --input-text: #1F2937;
+            --btn-text: #FFFFFF;
+            font-family: 'Inter', sans-serif;
+        }
+        body.arcane-theme {
+            --color-text: #EDE9FE;
+            --color-header: #A78BFA;
+            --color-accent: #C4B5FD;
+            --color-price: #F0ABFC;
+            --color-dim: #6B7280;
+            --color-border: #4C1D95;
+            --shadow-glow: 0 0 8px;
+            --color-bg: #1E1B4B;
+            --window-bg: rgba(31, 27, 75, 0.9);
+            --input-bg: #312E81;
+            --input-text: #EDE9FE;
+            --btn-text: #1E1B4B;
+            font-family: 'Raleway', sans-serif;
         }
         .cli-window {
             border: 1px solid var(--color-border);
             border-radius: 0.375rem;
             padding: 1rem;
-            background-color: rgba(20, 20, 20, 0.9);
+            background-color: var(--window-bg);
             box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
             position: relative; /* For positioning exit buttons */
         }
@@ -41,24 +91,24 @@
             display: inline-block;
             padding: 0.75rem 1.25rem;
             background-color: var(--color-accent);
-            color: #000000;
+            color: var(--btn-text);
             text-shadow: none;
             cursor: pointer;
             border: none;
             border-radius: 0.25rem;
             transition: all 0.2s ease-in-out;
         }
-        .btn:hover:not(:disabled) { background-color: #000000; color: var(--color-accent); box-shadow: 0 0 5px var(--color-accent); }
+        .btn:hover:not(:disabled) { background-color: var(--color-bg); color: var(--color-accent); box-shadow: 0 0 5px var(--color-accent); }
         .btn-secondary { background-color: transparent; color: var(--color-accent); border: 1px solid var(--color-accent); border-radius: 0.25rem; }
-        .btn-secondary:hover { background-color: var(--color-accent); color: #000000; }
+        .btn-secondary:hover { background-color: var(--color-accent); color: var(--btn-text); }
         .btn:disabled { background-color: #333; color: #888; cursor: not-allowed; opacity: 0.7; }
         .input-field, .select-field {
-            background-color: #1a1a1a;
+            background-color: var(--input-bg);
             border: 1px solid var(--color-border);
-            color: #ffffff;
+            color: var(--input-text);
             padding: 0.75rem;
             width: 100%;
-            font-family: 'VT323', monospace;
+            font-family: inherit;
             text-transform: uppercase;
             border-radius: 0.25rem;
         }
@@ -111,7 +161,7 @@
         .glow-once { animation: glow-success 0.7s ease-out; }
     </style>
 </head>
-<body class="p-4 sm:p-6 lg:p-8">
+<body class="p-4 sm:p-6 lg:p-8 cli-theme">
 
     <div id="toolbar" class="fixed top-0 left-0 right-0 p-4 z-50 flex justify-between items-center h-20 bg-[#0A0A0A]">
         <div id="toolbar-title" class="text-2xl hidden text-header"></div>
@@ -120,6 +170,14 @@
              <button id="exit-mode-btn" class="hidden">ⓧ</button>
              <button id="logout-btn" class="hidden">Logout</button>
         </div>
+    </div>
+
+    <button id="theme-btn" class="fixed bottom-4 left-4 z-50 btn-secondary">Theme</button>
+    <div id="theme-menu" class="hidden fixed bottom-16 left-4 z-50 cli-window flex flex-col gap-2">
+        <button data-theme="cli-theme" class="btn-secondary">CLI</button>
+        <button data-theme="fantasy-theme" class="btn-secondary">Fantasy</button>
+        <button data-theme="modern-theme" class="btn-secondary">Modern</button>
+        <button data-theme="arcane-theme" class="btn-secondary">Arcane</button>
     </div>
 
     <div id="app-container" class="max-w-7xl my-8 py-8 mx-auto">
@@ -312,6 +370,13 @@
         const inventoryModal = document.getElementById('inventory-modal');
         const updateSheetModal = document.getElementById('update-sheet-modal');
         const sheetJsonTextarea = document.getElementById('sheet-json-textarea');
+        const themeBtn = document.getElementById('theme-btn');
+        const themeMenu = document.getElementById('theme-menu');
+
+        function setTheme(theme) {
+            document.body.classList.remove('cli-theme','fantasy-theme','modern-theme','arcane-theme');
+            document.body.classList.add(theme);
+        }
 
         function closeNewKeyModal() {
             newKeyModal.classList.add('hidden');
@@ -353,6 +418,15 @@
                 }
             });
             document.getElementById('save-sheet-btn').addEventListener('click', handleSaveSheet);
+
+            // Theme
+            themeBtn.addEventListener('click', () => themeMenu.classList.toggle('hidden'));
+            themeMenu.querySelectorAll('button').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    setTheme(btn.dataset.theme);
+                    themeMenu.classList.add('hidden');
+                });
+            });
 
             // Check for saved key
             const savedKey = localStorage.getItem('dndShopCharacterKey');


### PR DESCRIPTION
## Summary
- Add fixed theme selector to the hub with CLI, Fantasy, Modern, and Arcane options
- Define theme-specific colors and fonts with CSS variables
- Wire up JavaScript to switch themes dynamically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a02a308660832a8eeddd4c4633ed4f