### PR TITLE
Redesign player hub layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>D&D Hub</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=VT323&family=Cormorant+Garamond:wght@400;700&family=Inter:wght@400;700&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
@@ -114,6 +115,21 @@
         .item-card { transition: transform 0.3s ease-out, box-shadow 0.3s ease-out, opacity 0.3s; touch-action: pan-y; }
         .item-card.sold-out { opacity: 0.5; }
         .item-card.swiping { transition: none; }
+        .dashboard-card {
+            background-color: var(--window-bg);
+            border: 1px solid var(--color-border);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            transition: all 0.3s ease-in-out;
+            display: flex;
+            flex-direction: column;
+        }
+        .dashboard-card:hover {
+            border-color: var(--color-header);
+            box-shadow: 0 0 10px rgba(0, 255, 136, 0.3);
+        }
+        .text-accent { color: var(--color-accent); }
+        .border-border { border-color: var(--color-border); }
         @keyframes glow-success { 0% { box-shadow: 0 0 0px var(--color-header); } 50% { box-shadow: 0 0 15px var(--color-header); } 100% { box-shadow: 0 0 0px var(--color-header); } }
         .glow-once { animation: glow-success 0.7s ease-out; }
     </style>
@@ -830,89 +846,127 @@
                 return acc;
             }, {});
             const classLevel = player.sheet?.classlevel || '';
-            const formattedClassLevel = classLevel && !classLevel.toLowerCase().startsWith('lvl') ? `Lvl ${classLevel}` : classLevel;
+            const formattedClassLevel = classLevel && !classLevel.toLowerCase().startsWith('lvl') ? `Level ${classLevel}` : classLevel;
+            const alignment = player.sheet?.alignment || '';
+            const subtitle = [formattedClassLevel, alignment].filter(Boolean).join(' | ');
+            const imgSrc = player.sheet?.avatarUrl || "https://i.imgur.com/zLRhJXx.png";
+            const hpValue = player.sheet?.combat?.hp ? `${player.sheet.combat.hp.current ?? "-"} / ${player.sheet.combat.hp.max ?? "-"}` : "-";
+            const acValue = player.sheet?.combat?.ac ?? "-";
+            const speedValue = player.sheet?.combat?.speed ?? "-";
 
             characterHubView.innerHTML = `
-                <details class="cli-window mb-6">
-                    <summary class="flex flex-col sm:flex-row sm:items-center sm:justify-between cursor-pointer">
-                        <span class="text-2xl text-header">&gt; ${player.name}</span>
-                        <span class="text-dim">${formattedClassLevel}</span>
-                    </summary>
-                    <div class="mt-2">
-                        <p class="text-dim">Key: <span id="player-key" class="text-header">${state.characterKey}</span></p>
-                    </div>
-                </details>
-                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                    <div class="cli-window flex flex-col">
-                        <h3 class="text-2xl text-header mb-4">> Character Sheet</h3>
-                        <a href="character.html" class="btn mt-auto w-full">Open</a>
-                    </div>
-                    <details id="inventory-details" class="cli-window flex flex-col">
-                        <summary class="text-2xl text-header cursor-pointer">&gt; Inventory</summary>
-                        <div class="mt-2">
-                            <p class="text-2xl text-price mb-4">${player.gold} GP</p>
-                            <div class="space-y-2 max-h-48 overflow-y-auto">${Object.keys(inventorySummary).length === 0 ? '<p class="text-dim">Empty.</p>' : Object.entries(inventorySummary).map(([name, count]) => `<div><span class="text-item-name">${name}</span> <span class="text-dim">(x${count})</span></div>`).join('')}</div>
-                            <button id="edit-inventory-btn" class="btn btn-secondary w-full mt-4">Edit</button>
+                <header class="mb-8">
+                    <div class="flex flex-col sm:flex-row items-center gap-6 p-4 border border-border rounded-lg bg-black/30">
+                        <div class="flex-shrink-0">
+                            <img src="${imgSrc}" alt="Character Avatar" class="w-32 h-32 object-cover rounded-full border-2 border-header shadow-[0_0_15px_rgba(0,255,136,0.5)]">
                         </div>
-                    </details>
-                    <details id="spell-management-details" class="cli-window flex flex-col md:col-span-2 lg:col-span-3">
-                        <summary class="text-2xl text-header cursor-pointer">&gt; Spell Management</summary>
-                        <div class="mt-4 space-y-4">
-                            <div class="flex justify-end">
-                                <button id="long-rest-btn" class="btn">Long Rest</button>
-                            </div>
-                            <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
-                                <div class="lg:col-span-1 space-y-6">
-                                    <div class="cli-window">
-                                        <h2 class="text-2xl text-header mb-4">&gt; Prepared Spells</h2>
-                                        <div id="prepared-spells-container" class="space-y-2 max-h-[40vh] md:max-h-[300px] overflow-y-auto custom-scrollbar pr-2"></div>
-                                    </div>
-                                    <div class="cli-window">
-                                        <h2 class="text-2xl text-header mb-4">&gt; Spell Slots</h2>
-                                        <div id="spell-slots-container" class="space-y-3"></div>
-                                    </div>
-                                </div>
-                                <details class="lg:col-span-1 cli-window">
-                                    <summary class="text-2xl text-header cursor-pointer">&gt; Spellbook</summary>
-                                    <div id="spellbook-container" class="space-y-2 h-[50vh] lg:h-[600px] overflow-y-auto custom-scrollbar pr-2 mt-4"></div>
-                                </details>
-                                <details class="lg:col-span-1 cli-window">
-                                    <summary class="text-2xl text-header cursor-pointer">&gt; Spell Search</summary>
-                                    <div class="mt-4">
-                                        <div class="flex gap-2 mb-4">
-                                            <input type="text" id="search-input" class="input-field" placeholder="Search Spells">
-                                            <button id="search-btn" class="btn">Go</button>
-                                        </div>
-                                        <div id="search-results-container" class="space-y-2 min-h-[100px] max-h-[50vh] lg:max-h-[520px] overflow-y-auto custom-scrollbar pr-2"></div>
-                                    </div>
-                                </details>
+                        <div class="flex-1 text-center sm:text-left">
+                            <h1 class="text-4xl text-header">${player.name}</h1>
+                            <p class="text-xl text-dim">${subtitle}</p>
+                            <div class="mt-3 flex items-center justify-center sm:justify-start gap-2 text-sm">
+                                <span class="text-dim">Key:</span>
+                                <span id="player-key" class="text-header tracking-widest cursor-pointer" title="Click to copy">${state.characterKey}</span>
+                                <i data-lucide="clipboard" class="w-4 h-4 text-dim"></i>
                             </div>
                         </div>
-                    </details>
-                    <details class="cli-window flex flex-col md:col-span-2 lg:col-span-3">
-                        <summary class="text-2xl text-header cursor-pointer">> Shops</summary>
-                        <div class="mt-4">
-                        ${state.activeShops.length === 0
-                            ? '<p class="text-dim">No active shops.</p>'
-                            : state.activeShops.map(s => `
-                                <div class="flex justify-between items-center mb-2">
-                                    <span class="text-item-name">${s.shopName || s.shopType}</span>
-                                    <button class="btn join-shop-btn" data-shop-id="${s.id}">Enter</button>
-                                </div>
-                            `).join('')}
+                        <div class="grid grid-cols-3 gap-4 text-center text-lg w-full sm:w-auto">
+                            <div class="dashboard-card !p-3">
+                                <span class="text-dim">HP</span>
+                                <span class="text-2xl text-accent">${hpValue}</span>
+                            </div>
+                            <div class="dashboard-card !p-3">
+                                <span class="text-dim">AC</span>
+                                <span class="text-2xl text-accent">${acValue}</span>
+                            </div>
+                            <div class="dashboard-card !p-3">
+                                <span class="text-dim">Speed</span>
+                                <span class="text-2xl text-accent">${speedValue}</span>
+                            </div>
                         </div>
-                    </details>
-                </div>
+                    </div>
+                </header>
+                <main class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    <div class="dashboard-card lg:col-span-1">
+                        <div class="flex items-center gap-3 mb-4">
+                            <i data-lucide="scroll-text" class="w-8 h-8 text-header"></i>
+                            <h2 class="text-2xl text-header">&gt; Character Sheet</h2>
+                        </div>
+                        <p class="text-dim mb-4 flex-grow">Review your full character details, including abilities, skills, and background.</p>
+                        <a href="character.html" class="btn mt-auto">Open Full Sheet</a>
+                    </div>
+
+                    <div class="dashboard-card lg:col-span-2" id="inventory-card">
+                        <div class="flex items-center gap-3 mb-4">
+                            <i data-lucide="backpack" class="w-8 h-8 text-header"></i>
+                            <h2 class="text-2xl text-header">&gt; Inventory</h2>
+                        </div>
+                        <div class="flex-grow mb-4">
+                            <p class="text-3xl text-price mb-4">${player.gold} GP</p>
+                            <div class="grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-2 text-lg max-h-32 overflow-y-auto">
+                                ${Object.keys(inventorySummary).length === 0 ? '<p class="text-dim">Empty.</p>' : Object.entries(inventorySummary).map(([name, count]) => `<div><span class="text-accent">${name}</span> <span class="text-dim">(x${count})</span></div>`).join('')}
+                            </div>
+                        </div>
+                        <button id="edit-inventory-btn" class="btn mt-auto">Manage Inventory</button>
+                    </div>
+
+                    <div id="spell-management-details" class="dashboard-card lg:col-span-2">
+                        <div class="flex items-center gap-3 mb-4">
+                            <i data-lucide="sparkles" class="w-8 h-8 text-header"></i>
+                            <h2 class="text-2xl text-header">&gt; Spellcasting</h2>
+                            <div class="ml-auto"><button id="long-rest-btn" class="btn">Long Rest</button></div>
+                        </div>
+                        <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-4 flex-grow">
+                            <div>
+                                <h3 class="text-xl text-accent mb-2">Spell Slots</h3>
+                                <div class="space-y-2" id="spell-slots-container"></div>
+                            </div>
+                            <div>
+                                <h3 class="text-xl text-accent mb-2">Prepared Spells</h3>
+                                <ul class="list-disc list-inside text-dim" id="prepared-spells-container"></ul>
+                            </div>
+                        </div>
+                        <div class="mt-4 grid grid-cols-1 lg:grid-cols-2 gap-4">
+                            <details class="cli-window">
+                                <summary class="text-xl text-header cursor-pointer">Spellbook</summary>
+                                <div id="spellbook-container" class="space-y-2 h-[50vh] lg:h-[600px] overflow-y-auto custom-scrollbar pr-2 mt-4"></div>
+                            </details>
+                            <details class="cli-window">
+                                <summary class="text-xl text-header cursor-pointer">Spell Search</summary>
+                                <div class="mt-4">
+                                    <div class="flex gap-2 mb-4">
+                                        <input type="text" id="search-input" class="input-field" placeholder="Search Spells">
+                                        <button id="search-btn" class="btn">Go</button>
+                                    </div>
+                                    <div id="search-results-container" class="space-y-2 min-h-[100px] max-h-[50vh] lg:max-h-[520px] overflow-y-auto custom-scrollbar pr-2"></div>
+                                </div>
+                            </details>
+                        </div>
+                    </div>
+
+                    <div class="dashboard-card lg:col-span-1">
+                        <div class="flex items-center gap-3 mb-4">
+                            <i data-lucide="store" class="w-8 h-8 text-header"></i>
+                            <h2 class="text-2xl text-header">&gt; Shops</h2>
+                        </div>
+                        <div class="space-y-3 flex-grow mb-4">
+                            ${state.activeShops.length === 0
+                                ? '<p class="text-dim">No active shops.</p>'
+                                : state.activeShops.map(s => `
+                                    <div class="flex justify-between items-center">
+                                        <span class="text-accent">${s.shopName || s.shopType}</span>
+                                        <button class="btn-secondary !p-2 text-sm join-shop-btn" data-shop-id="${s.id}">Enter</button>
+                                    </div>
+                                `).join('')}
+                        </div>
+                    </div>
+                </main>
             `;
+            lucide.createIcons();
             document.querySelectorAll('.join-shop-btn').forEach(btn => {
                 btn.addEventListener('click', e => joinShop(e.target.dataset.shopId));
             });
             document.getElementById('edit-inventory-btn')?.addEventListener('click', handleEditInventory);
             document.getElementById('player-key')?.addEventListener('click', () => navigator.clipboard.writeText(state.characterKey));
-            const invDetails = document.getElementById('inventory-details');
-            if (window.innerWidth >= 768) {
-                invDetails.setAttribute('open', '');
-            }
             initializeSpellManagement();
         }
 


### PR DESCRIPTION
## Summary
- Modernize player hub with dashboard-style layout and quick stats
- Add Lucide icons and card styling utilities

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d9871220832a8318bdcbbe92012b