### PR TITLE
Refine navigation and autofill login key

### DIFF
--- a/character.html
+++ b/character.html
@@ -103,13 +103,20 @@
         .slot-available { background-color: var(--color-header); box-shadow: var(--shadow-glow) var(--color-header); }
         .slot-expended { background-color: transparent; box-shadow: none; }
         .cast-btn { background-color: var(--color-bg); white-space: nowrap; }
+        #dm-tools-btn, #logout-btn { background: none; border: none; color: var(--color-accent); font-size: 1.25rem; cursor: pointer; }
+        #dm-tools-btn:hover, #logout-btn:hover { color: var(--color-header); text-decoration: underline; }
+        #exit-mode-btn { background: none; border: none; color: var(--color-header); font-size: 1.75rem; line-height: 1; cursor: pointer; padding: 0 0.5rem; }
+        #exit-mode-btn:hover { color: var(--color-accent); }
     </style>
 </head>
 <body class="p-4 sm:p-6 lg:p-8">
 
     <!-- Top Navigation -->
-    <div class="fixed top-0 left-0 right-0 h-16 bg-black/80 backdrop-blur-sm border-b border-border z-50 flex items-center justify-end px-4">
-        <a href="index.html" class="text-header hover:text-accent"><i data-lucide="x" class="w-6 h-6"></i></a>
+    <div id="toolbar" class="fixed top-0 left-0 right-0 p-4 z-50 flex justify-between items-center h-20 bg-[#0A0A0A]">
+        <div id="toolbar-title" class="text-2xl hidden text-header"></div>
+        <div id="controls-container" class="relative ml-auto flex items-center gap-4">
+             <a id="exit-mode-btn" href="index.html">ⓧ</a>
+        </div>
     </div>
 
     <!-- Main Container -->

--- a/index.html
+++ b/index.html
@@ -388,10 +388,10 @@
             });
             document.getElementById('save-sheet-btn').addEventListener('click', handleSaveSheet);
 
-            // Check for saved key
+            // Check for saved key and pre-fill login field
             const savedKey = localStorage.getItem('dndShopCharacterKey');
             if (savedKey) {
-                loginWithKey(savedKey);
+                document.getElementById('character-key-input').value = savedKey;
             }
             listenToActiveShops();
             render();
@@ -793,13 +793,17 @@
 
             controlsContainer.classList.remove('hidden');
 
-            const showDmTools = !state.isDM;
+            const showDmTools = !state.isDM && !loggedIn;
             if (state.isDM || inShop) {
                 exitModeBtn.classList.remove('hidden');
-                toolbarTitle.classList.remove('hidden');
-                toolbarTitle.textContent = state.isDM ? (inShop ? '> DM Mode' : '> DM Hub') : '> Player Mode';
             } else {
                 exitModeBtn.classList.add('hidden');
+            }
+
+            if (state.isDM) {
+                toolbarTitle.classList.remove('hidden');
+                toolbarTitle.textContent = inShop ? '> DM Mode' : '> DM Hub';
+            } else {
                 toolbarTitle.classList.add('hidden');
             }
             if (showDmTools) {
@@ -808,7 +812,7 @@
                 dmToolsBtn.classList.add('hidden');
             }
 
-            if (loggedIn) {
+            if (loggedIn && !inShop && !state.isDM) {
                 logoutBtn.classList.remove('hidden');
             } else {
                 logoutBtn.classList.add('hidden');
@@ -978,21 +982,24 @@
                 <div class="cli-window max-w-md mx-auto">
                     <h2 class="text-2xl mb-4 text-header">> DM Tools</h2>
                     <div class="space-y-2">
-                        <button id="dm-create-shop-btn" class="btn w-full">Create New Shop</button>
                         <button id="dm-manage-players-btn" class="btn w-full">Manage Players</button>
                     </div>
                 </div>
                 <div class="mt-8 cli-window max-w-md mx-auto">
                     <h2 class="text-2xl mb-4 text-header">> Your Shops</h2>
-                    ${state.dmShops.length === 0
-                        ? '<p class="text-dim">No shops.</p>'
-                        : state.dmShops.map(s => `
-                            <div class="flex items-center mb-2 gap-2">
-                                <button class="btn flex-1 text-left dm-enter-shop-btn" data-shop-id="${s.id}">${s.shopName || s.shopType}</button>
-                                <input type="checkbox" class="dm-active-checkbox" data-shop-id="${s.id}" ${s.active ? 'checked' : ''}>
-                                <button class="text-red-500 hover:text-red-400 dm-delete-shop-btn" data-shop-id="${s.id}">X</button>
-                            </div>
-                        `).join('')}
+                    <div class="space-y-2">
+                        <button id="dm-create-shop-btn" class="btn w-full">Create New Shop</button>
+                        <div class="border-t border-border my-2"></div>
+                        ${state.dmShops.length === 0
+                            ? '<p class="text-dim">No shops.</p>'
+                            : state.dmShops.map(s => `
+                                <div class="flex items-center mb-2 gap-2">
+                                    <button class="btn flex-1 text-left dm-enter-shop-btn" data-shop-id="${s.id}">${s.shopName || s.shopType}</button>
+                                    <input type="checkbox" class="dm-active-checkbox" data-shop-id="${s.id}" ${s.active ? 'checked' : ''}>
+                                    <button class="text-red-500 hover:text-red-400 dm-delete-shop-btn" data-shop-id="${s.id}">X</button>
+                                </div>
+                            `).join('')}
+                    </div>
                 </div>
             `;
             document.getElementById('dm-create-shop-btn').addEventListener('click', showCreateShopView);

--- a/spells.html
+++ b/spells.html
@@ -31,6 +31,7 @@
             font-size: 20px;
             line-height: 1.6;
             overflow-x: hidden;
+            padding-top: 5rem;
         }
         .cli-window {
             border: 1px solid var(--color-border);
@@ -110,15 +111,25 @@
             background-color: transparent;
             box-shadow: none;
         }
+        #dm-tools-btn, #logout-btn { background: none; border: none; color: var(--color-accent); font-size: 1.25rem; cursor: pointer; }
+        #dm-tools-btn:hover, #logout-btn:hover { color: var(--color-header); text-decoration: underline; }
+        #exit-mode-btn { background: none; border: none; color: var(--color-header); font-size: 1.75rem; line-height: 1; cursor: pointer; padding: 0 0.5rem; }
+        #exit-mode-btn:hover { color: var(--color-accent); }
     </style>
 </head>
 <body class="p-4 sm:p-6 lg:p-8">
+
+    <div id="toolbar" class="fixed top-0 left-0 right-0 p-4 z-50 flex justify-between items-center h-20 bg-[#0A0A0A]">
+        <div id="toolbar-title" class="text-2xl hidden text-header"></div>
+        <div id="controls-container" class="relative ml-auto flex items-center gap-4">
+             <a id="exit-mode-btn" href="index.html">ⓧ</a>
+        </div>
+    </div>
 
     <header class="max-w-7xl mx-auto mb-6 flex flex-col sm:flex-row justify-between items-center gap-4">
         <h1 class="text-3xl text-header text-center sm:text-left">> Spell Management</h1>
         <div class="flex gap-2 flex-wrap justify-center">
             <button id="long-rest-btn" class="btn">Long Rest</button>
-            <a href="index.html" class="btn btn-secondary">Back to Hub</a>
         </div>
     </header>
 


### PR DESCRIPTION
## Summary
- Autofill saved character key in login field
- Standardize toolbar across pages with dynamic button visibility
- Move "Create New Shop" into DM shop list with divider

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f17ffab0832a96ce163af4e3b640