### PR TITLE
Remove cantrip cast button and add dynamic price modifier

### DIFF
--- a/character.html
+++ b/character.html
@@ -115,12 +115,12 @@
     <div id="toolbar" class="fixed top-0 left-0 right-0 p-4 z-50 flex justify-between items-center h-20 bg-[#0A0A0A]">
         <div id="toolbar-title" class="text-2xl hidden text-header"></div>
         <div id="controls-container" class="relative ml-auto flex items-center gap-4">
-             <a id="exit-mode-btn" href="index.html">ⓧ</a>
+             <button id="exit-mode-btn" onclick="history.back()">C</button>
         </div>
     </div>
 
     <!-- Main Container -->
-    <div class="max-w-7xl mx-auto relative">
+    <div class="max-w-7xl mx-auto relative mt-8 pt-8">
 
         <!-- Character Overview -->
         <header class="bg-black/80 backdrop-blur-sm p-4 rounded-b-lg mb-6 border-x border-b border-border">

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
         <div id="toolbar-title" class="text-2xl hidden text-header"></div>
         <div id="controls-container" class="relative ml-auto flex items-center gap-4">
              <button id="dm-tools-btn" class="hidden">DM Tools</button>
-             <button id="exit-mode-btn" class="hidden">ⓧ</button>
+             <button id="exit-mode-btn" class="hidden">C</button>
              <button id="logout-btn" class="hidden">Logout</button>
         </div>
     </div>
@@ -1185,8 +1185,6 @@ async function handleDMActiveChange(e) {
                             }
                         }
                         buttonHtml = castButtons ? `<div class="flex gap-1 flex-wrap justify-center sm:justify-end">${castButtons}</div>` : `<p class="text-dim text-right">> No Slots</p>`;
-                    } else {
-                        buttonHtml = `<div class="flex justify-end"><button class="btn-secondary cast-btn" data-cast-level="0">Cast</button></div>`;
                     }
                 }
                 return `
@@ -1538,6 +1536,8 @@ function getModifiedPrice(basePrice) {
             document.querySelectorAll('.price-mod-btn').forEach(btn => btn.addEventListener('click', (e) => {
                 const value = parseInt(e.target.dataset.value, 10);
                 const newVal = state.shopData.priceModifier === value ? 0 : value;
+                state.shopData.priceModifier = newVal;
+                render();
                 updateDoc(doc(db, 'shops', state.shopId), { priceModifier: newVal });
             }));
             document.getElementById('toggle-active-btn')?.addEventListener('click', () => { updateDoc(doc(db, 'shops', state.shopId), { active: !state.shopData.active }); });

--- a/spells.html
+++ b/spells.html
@@ -122,7 +122,7 @@
     <div id="toolbar" class="fixed top-0 left-0 right-0 p-4 z-50 flex justify-between items-center h-20 bg-[#0A0A0A]">
         <div id="toolbar-title" class="text-2xl hidden text-header"></div>
         <div id="controls-container" class="relative ml-auto flex items-center gap-4">
-             <a id="exit-mode-btn" href="index.html">ⓧ</a>
+             <button id="exit-mode-btn" onclick="history.back()">C</button>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- hide cast buttons for cantrips on player hub
- make price modifier update prices immediately in shop and cart
- use toolbar C button to return to previous page and add spacing on character sheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f5e91b78832a9bc936020118675f