### PR TITLE
feat: improve toolbar icons and spell slot persistence

### DIFF
--- a/character.html
+++ b/character.html
@@ -115,7 +115,7 @@
     <div id="toolbar" class="fixed top-0 left-0 right-0 p-4 z-50 flex justify-between items-center h-20 bg-[#0A0A0A]">
         <div id="toolbar-title" class="text-2xl hidden text-header"></div>
         <div id="controls-container" class="relative ml-auto flex items-center gap-4">
-             <button id="exit-mode-btn" onclick="history.back()">C</button>
+             <button id="exit-mode-btn" onclick="history.back()"><i data-lucide="chevron-left" class="w-6 h-6"></i></button>
         </div>
     </div>
 
@@ -123,7 +123,7 @@
     <div class="max-w-7xl mx-auto relative mt-8 pt-8">
 
         <!-- Character Overview -->
-        <header class="bg-black/80 backdrop-blur-sm p-4 rounded-b-lg mb-6 border-x border-b border-border">
+        <header class="bg-black/80 backdrop-blur-sm p-4 rounded-lg mb-6 border border-border">
             <div class="flex flex-col sm:flex-row items-center gap-4">
                 <!-- Avatar and Name -->
                 <div class="flex items-center gap-4 flex-1">
@@ -361,6 +361,15 @@
             }
         };
 
+        const savedSlots = localStorage.getItem('spellSlots');
+        if (savedSlots) {
+            try { state.spellSlots = JSON.parse(savedSlots); } catch {}
+        }
+
+        function saveSpellSlots() {
+            localStorage.setItem('spellSlots', JSON.stringify(state.spellSlots));
+        }
+
         function renderSpellSlots() {
             const container = document.getElementById('spell-slots-container');
             container.innerHTML = '';
@@ -368,8 +377,8 @@
                 const { max, expended } = state.spellSlots[level];
                 let slotsHtml = '';
                 for (let i = 0; i < max; i++) {
-                    const isExpended = i < expended;
-                    slotsHtml += `<div class="slot-segment ${isExpended ? 'slot-expended' : 'slot-available'}" data-level="${level}" data-index="${i}"></div>`;
+                    const isAvailable = i < (max - expended);
+                    slotsHtml += `<div class="slot-segment ${isAvailable ? 'slot-available' : 'slot-expended'}" data-level="${level}" data-index="${i}"></div>`;
                 }
                 container.innerHTML += `
                     <div class="flex items-center justify-start gap-4">
@@ -426,6 +435,7 @@
             const slot = state.spellSlots[level];
             if (!slot || slot.expended >= slot.max) return;
             slot.expended++;
+            saveSpellSlots();
             renderSpellSlots();
         }
 
@@ -435,16 +445,20 @@
             const index = Number(e.target.dataset.index);
             const slot = state.spellSlots[level];
             if (!slot) return;
-            if (index < slot.expended) {
-                slot.expended--;
-            } else if (slot.expended < slot.max) {
-                slot.expended++;
+            const maxSlots = slot.max;
+            const currentAvailable = maxSlots - slot.expended;
+            if (currentAvailable === index + 1) {
+                slot.expended = maxSlots - index;
+            } else {
+                slot.expended = maxSlots - (index + 1);
             }
+            saveSpellSlots();
             renderSpellSlots();
         }
 
         function handleLongRest() {
             Object.values(state.spellSlots).forEach(s => s.expended = 0);
+            saveSpellSlots();
             renderSpellSlots();
         }
 
@@ -456,6 +470,7 @@
 
         renderPreparedSpells();
         renderSpellSlots();
+        saveSpellSlots();
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
         <div id="toolbar-title" class="text-2xl hidden text-header"></div>
         <div id="controls-container" class="relative ml-auto flex items-center gap-4">
              <button id="dm-tools-btn" class="hidden">DM Tools</button>
-             <button id="exit-mode-btn" class="hidden">C</button>
+             <button id="exit-mode-btn" class="hidden"><i data-lucide="log-out" class="w-6 h-6"></i></button>
              <button id="logout-btn" class="hidden">Logout</button>
         </div>
     </div>
@@ -1042,6 +1042,15 @@ async function handleDMActiveChange(e) {
                 },
             };
 
+            const savedSlots = localStorage.getItem('spellSlots');
+            if (savedSlots) {
+                try { spellState.spellSlots = JSON.parse(savedSlots); } catch {}
+            }
+
+            function saveSpellSlots() {
+                localStorage.setItem('spellSlots', JSON.stringify(spellState.spellSlots));
+            }
+
             const API_BASE = "https://www.dnd5eapi.co/api";
 
             async function searchSpellsAPI(query) {
@@ -1082,6 +1091,7 @@ async function handleDMActiveChange(e) {
                 renderPreparedSpells();
                 renderSpellbook();
                 renderSpellSlots();
+                saveSpellSlots();
             }
 
             function renderSpellSlots() {
@@ -1238,6 +1248,7 @@ async function handleDMActiveChange(e) {
                 const levelStr = String(spellLevelToUse);
                 if (spellState.spellSlots[levelStr] && spellState.spellSlots[levelStr].expended < spellState.spellSlots[levelStr].max) {
                     spellState.spellSlots[levelStr].expended++;
+                    saveSpellSlots();
                     renderAll();
                 } else {
                     const originalText = button.textContent;
@@ -1262,6 +1273,7 @@ async function handleDMActiveChange(e) {
                 } else {
                     levelData.expended = maxSlots - (index + 1);
                 }
+                saveSpellSlots();
                 renderSpellSlots();
             }
 
@@ -1269,6 +1281,7 @@ async function handleDMActiveChange(e) {
                 for (const level in spellState.spellSlots) {
                     spellState.spellSlots[level].expended = 0;
                 }
+                saveSpellSlots();
                 renderSpellSlots();
                 renderPreparedSpells();
             }

--- a/spells.html
+++ b/spells.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Spell Management</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
@@ -122,7 +123,7 @@
     <div id="toolbar" class="fixed top-0 left-0 right-0 p-4 z-50 flex justify-between items-center h-20 bg-[#0A0A0A]">
         <div id="toolbar-title" class="text-2xl hidden text-header"></div>
         <div id="controls-container" class="relative ml-auto flex items-center gap-4">
-             <button id="exit-mode-btn" onclick="history.back()">C</button>
+             <button id="exit-mode-btn" onclick="history.back()"><i data-lucide="log-out" class="w-6 h-6"></i></button>
         </div>
     </div>
 
@@ -175,6 +176,7 @@
     </main>
 
     <script type="module">
+        lucide.createIcons();
         // --- STATE MANAGEMENT (SAMPLE DATA) ---
         let state = {
             knownSpells: [], // Array of spell objects from API


### PR DESCRIPTION
## Summary
- add full border and chevron back icon to character sheet header
- replace placeholder toolbar "C" buttons with proper icons
- persist spell slot state across pages and render slots right-to-left

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fa4e0344832ab01af8b709330606