### PR TITLE
Fix spell slot refresh and update back button

### DIFF
--- a/character.html
+++ b/character.html
@@ -115,7 +115,7 @@
     <div id="toolbar" class="fixed top-0 left-0 right-0 p-4 z-50 flex justify-between items-center h-20 bg-[#0A0A0A]">
         <div id="toolbar-title" class="text-2xl hidden text-header"></div>
         <div id="controls-container" class="relative ml-auto flex items-center gap-4">
-             <button id="exit-mode-btn" onclick="history.back()"><i data-lucide="chevron-left" class="w-6 h-6"></i></button>
+             <button id="exit-mode-btn" onclick="history.back()"><i data-lucide="x" class="w-6 h-6"></i></button>
         </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -1307,6 +1307,15 @@ async function handleDMActiveChange(e) {
                 if (e.target.classList.contains('spell-name')) handleToggleSpellDetails(e);
             });
 
+            window.addEventListener('pageshow', () => {
+                const savedSlots = localStorage.getItem('spellSlots');
+                if (savedSlots) {
+                    try { spellState.spellSlots = JSON.parse(savedSlots); } catch {}
+                }
+                renderSpellSlots();
+                renderPreparedSpells();
+            });
+
             loadInitialSpells();
         }
 


### PR DESCRIPTION
## Summary
- Sync spell slots from local storage when returning to the player hub
- Replace character sheet back button with an "X" icon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ffa6de04832a8035a59eb202d0c6