### PR TITLE
Refactor shop UI and improve spell management

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@
         <!-- DM View -->
         <div id="dm-view" class="hidden"></div>
         <!-- Player View -->
-        <div id="player-view" class="hidden"></div>
+        <div id="player-view" class="hidden max-w-7xl mx-auto"></div>
     </div>
 
     <!-- New Key Modal (Moved outside app-container) -->
@@ -1043,8 +1043,12 @@ async function handleDMActiveChange(e) {
                 },
             };
 
+            const savedSlots = localStorage.getItem('spellSlots');
+            if (savedSlots) { try { spellState.spellSlots = JSON.parse(savedSlots); } catch {} }
+
             async function saveSpellSlots() {
                 try {
+                    localStorage.setItem('spellSlots', JSON.stringify(spellState.spellSlots));
                     await updateDoc(doc(db, 'characters', state.characterKey), { spellSlots: spellState.spellSlots });
                     if (state.playerData) state.playerData.spellSlots = spellState.spellSlots;
                 } catch (err) {
@@ -1097,25 +1101,28 @@ async function handleDMActiveChange(e) {
 
             function renderSpellSlots() {
                 const container = module.querySelector('#spell-slots-container');
-                container.innerHTML = '';
-                if (Object.keys(spellState.spellSlots).length === 0) {
-                    container.innerHTML = '<p class="text-dim">> No spell slots.</p>';
-                    return;
-                }
-                for (const level in spellState.spellSlots) {
-                    const levelData = spellState.spellSlots[level];
-                    let slotsHtml = '';
-                    for (let i = 0; i < levelData.max; i++) {
-                        const isAvailable = i < (levelData.max - levelData.expended);
-                        const slotClass = isAvailable ? 'slot-available' : 'slot-expended';
-                        slotsHtml += `<div class="slot-segment ${slotClass} slot" data-level="${level}" data-index="${i}"></div>`;
+                if (!container.innerHTML) {
+                    let html = '';
+                    for (const level in spellState.spellSlots) {
+                        html += `<div class="flex items-center justify-start gap-4" data-level-bar="${level}">`;
+                        html += `<span class="text-item-name w-20">Level ${level}</span><div class="slot-bar">`;
+                        const { max } = spellState.spellSlots[level];
+                        for (let i = 0; i < max; i++) {
+                            html += `<div class="slot-segment slot" data-level="${level}" data-index="${i}"></div>`;
+                        }
+                        html += `</div></div>`;
                     }
-                    container.innerHTML += `
-                        <div class="flex items-center justify-start gap-4">
-                            <span class="text-item-name w-20">Level ${level}</span>
-                            <div class="slot-bar">${slotsHtml}</div>
-                        </div>
-                    `;
+                    container.innerHTML = html;
+                }
+
+                for (const level in spellState.spellSlots) {
+                    const { max, expended } = spellState.spellSlots[level];
+                    const slots = container.querySelectorAll(`.slot[data-level="${level}"]`);
+                    slots.forEach((slot, i) => {
+                        const isAvailable = i < (max - expended);
+                        slot.classList.toggle('slot-available', isAvailable);
+                        slot.classList.toggle('slot-expended', !isAvailable);
+                    });
                 }
             }
 
@@ -1310,9 +1317,9 @@ async function handleDMActiveChange(e) {
             });
 
             window.addEventListener('pageshow', () => {
-                spellState.spellSlots = state.playerData.spellSlots || spellState.spellSlots;
-                renderSpellSlots();
-                renderPreparedSpells();
+                const savedSlots2 = localStorage.getItem('spellSlots');
+                if (savedSlots2) { try { spellState.spellSlots = JSON.parse(savedSlots2); } catch {} }
+                renderAll();
             });
 
             loadInitialSpells();
@@ -1376,16 +1383,78 @@ function getModifiedPrice(basePrice) {
             const { shopkeeper, inventory, carts, shopType, shopName } = state.shopData;
             const playerCart = carts[state.characterKey] || { items: [] };
             const cartTotal = playerCart.items.reduce((sum, item) => sum + getModifiedPrice(item.price), 0);
-            playerView.innerHTML = `<div class="grid grid-cols-1 md:grid-cols-3 gap-6 text-lg">
-                <div class="md:col-span-2">
-                    <div class="cli-window mb-6"><h1 class="text-3xl text-header">${shopName}</h1><p class="text-xl text-dim">(${shopType})</p><p class="text-xl">> Shopkeeper: <span class="text-item-name">${shopkeeper.name}</span></p><p class="text-xl text-dim">> ${shopkeeper.description||'...'}</p></div>
+            playerView.innerHTML = `
+                <div class="pb-24 lg:pb-0 lg:grid lg:grid-cols-3 lg:gap-6 text-lg">
+                    <div class="lg:col-span-2">
+                        <div class="cli-window mb-6">
+                            <h1 class="text-3xl text-header">${shopName}</h1>
+                            <p class="text-xl text-dim">(${shopType})</p>
+                            <p class="mt-2">> Shopkeeper: <span class="text-item-name">${shopkeeper.name}</span></p>
+                            <p class="text-dim">> ${shopkeeper.description||'...'}</p>
+                        </div>
 
-                    <div class="cli-window"><h2 class="text-2xl mb-4 text-header">> Items for Sale</h2><div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">${inventory.map(item=>`<div class="item-card ${item.quantity === 0 ? 'sold-out' : ''} border border-white/50 p-3 flex flex-col justify-between" data-item-id="${item.id}"><p class="text-xl"><span class="text-item-name">${item.name}</span> <span class="text-dim">(x${item.quantity})</span></p>${item.details?`<p class="text-sm text-dim">${item.details}</p>`:''}<p class="text-price">${item.quantity > 0 ? `${getModifiedPrice(item.price)} GP` : 'SOLD OUT'}</p><div class="mt-auto pt-2 flex justify-end items-center gap-2">${item.quantity > 0 ? `<button class="btn add-to-cart-btn" data-item-id="${item.id}">Add</button>`: ''}</div></div>`).join('')}</div></div>
+                        <div class="cli-window">
+                            <h2 class="text-2xl mb-4 text-header">> Items for Sale</h2>
+                            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                ${inventory.map(item=>`
+                                    <div class="item-card ${item.quantity === 0 ? 'sold-out' : ''}" data-item-id="${item.id}">
+                                        <div class="border border-border p-3 flex flex-col justify-between rounded-lg h-full">
+                                            <div>
+                                                <p class="text-xl"><span class="text-item-name">${item.name}</span> <span class="text-dim">(x${item.quantity})</span></p>
+                                                ${item.details ? `<p class="text-sm text-dim mt-1">${item.details}</p>`:''}
+                                            </div>
+                                            <div class="mt-3 flex justify-between items-center">
+                                                <p class="text-price text-xl">${item.quantity > 0 ? `${getModifiedPrice(item.price)} GP` : 'SOLD OUT'}</p>
+                                                ${item.quantity > 0 ? `<button class="btn !p-2 add-to-cart-btn"><i data-lucide="plus" class="w-5 h-5"></i></button>`: ''}
+                                            </div>
+                                        </div>
+                                    </div>
+                                `).join('')}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="hidden lg:block lg:col-span-1">
+                        <div class="cli-window sticky top-24">
+                            <h2 class="text-2xl mb-4 text-header">> ${state.playerData.name}'s Purse</h2>
+                            <p class="text-2xl text-price">${state.playerData.gold} GP</p>
+                            <hr class="border-border my-4">
+                            <h2 class="text-2xl mb-4 text-header">> Your Cart</h2>
+                            <div id="player-cart-list-desktop" class="space-y-2 mb-4 min-h-[50px] max-h-96 overflow-y-auto custom-scrollbar pr-2">
+                                ${playerCart.items.length===0?'<p class="text-dim">Your cart is empty.</p>':playerCart.items.map((item,index)=>`
+                                    <div class="flex justify-between items-center">
+                                        <span>- <span class="text-item-name">${item.name}</span></span>
+                                        <button class="text-red-500 hover:text-red-400 remove-from-cart-btn" data-index="${index}">[X]</button>
+                                    </div>`).join('')}
+                            </div>
+                            <hr class="border-border my-4">
+                            <p class="text-xl text-right">> Total: <span class="text-price">${cartTotal} GP</span></p>
+                        </div>
+                    </div>
                 </div>
-                <div class="md:col-span-1">
-                    <div class="cli-window sticky top-24"><h2 class="text-2xl mb-4 text-header">> ${state.playerData.name}'s Purse</h2><p class="text-2xl text-price">${state.playerData.gold} GP</p><hr class="border-white/50 my-4"><h2 class="text-2xl mb-4 text-header">> Your Cart</h2><div id="player-cart-list" class="space-y-2 mb-4 min-h-[50px]">${playerCart.items.length===0?'<p class="text-dim">Your cart is empty.</p>':playerCart.items.map((item,index)=>`<div class="flex justify-between items-center"><span>- <span class="text-item-name">${item.name}</span></span><button class="text-red-500 hover:text-red-400 remove-from-cart-btn" data-index="${index}">[X]</button></div>`).join('')}</div><hr class="border-white/50 my-4"><p class="text-xl text-right">> Total: <span class="text-price">${cartTotal} GP</span></p></div>
+
+                <div id="mobile-cart-bar" class="lg:hidden fixed bottom-0 left-0 right-0 bg-[var(--window-bg)] border-t-2 border-[var(--color-header)] p-3 z-40">
+                     <details>
+                        <summary class="flex justify-between items-center cursor-pointer">
+                            <div>
+                                <h3 class="text-header text-xl">> Your Cart (${playerCart.items.length})</h3>
+                                <p class="text-price text-lg">${cartTotal} GP</p>
+                            </div>
+                            <i data-lucide="chevron-up" class="w-6 h-6 text-header"></i>
+                        </summary>
+                        <div class="mt-4 pt-4 border-t border-border max-h-64 overflow-y-auto custom-scrollbar pr-2">
+                             <div id="player-cart-list-mobile" class="space-y-3">
+                                ${playerCart.items.length===0?'<p class="text-dim">Your cart is empty.</p>':playerCart.items.map((item,index)=>`
+                                    <div class="flex justify-between items-center">
+                                        <span>- <span class="text-item-name">${item.name}</span></span>
+                                        <button class="text-red-500 hover:text-red-400 remove-from-cart-btn" data-index="${index}">[X]</button>
+                                    </div>`).join('')}
+                             </div>
+                        </div>
+                     </details>
                 </div>
-            </div>`;
+            `;
+            lucide.createIcons();
             attachPlayerListeners();
         }
         


### PR DESCRIPTION
## Summary
- Restyle player-facing shop with responsive layout and mobile cart while keeping existing navbar
- Optimize spell slot rendering and persist slots to localStorage to avoid full rerenders

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a110036124832abbc35d2185b60f59