### PR TITLE
fix: prevent spell module flashing on cast

### DIFF
--- a/index.html
+++ b/index.html
@@ -1258,7 +1258,7 @@ async function handleDMActiveChange(e) {
                 if (spellState.spellSlots[levelStr] && spellState.spellSlots[levelStr].expended < spellState.spellSlots[levelStr].max) {
                     spellState.spellSlots[levelStr].expended++;
                     saveSpellSlots();
-                    renderAll();
+                    renderSpellSlots();
                 } else {
                     const originalText = button.textContent;
                     button.textContent = "No Slots!";

--- a/spells.html
+++ b/spells.html
@@ -398,7 +398,7 @@
             const levelStr = String(spellLevelToUse);
             if (state.spellSlots[levelStr] && state.spellSlots[levelStr].expended < state.spellSlots[levelStr].max) {
                 state.spellSlots[levelStr].expended++;
-                renderAll(); // Rerender to update slots and cast buttons
+                renderSpellSlots();
             } else {
                 const originalText = button.textContent;
                 button.textContent = "No Slots!";


### PR DESCRIPTION
## Summary
- avoid rerendering the entire spell module when casting a spell in the player hub
- update standalone spell management to only refresh slot visuals after casting

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a112a06cb4832abce069d64856180a