### PR TITLE
Add DM shop view page with existing navbar

### DIFF
--- a/dm-shop.html
+++ b/dm-shop.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>D&D DM Shop View</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
+    <style>
+        html { scroll-behavior: smooth; }
+        body {
+            font-size: 20px;
+            line-height: 1.6;
+            overflow-x: hidden;
+            padding-top: 5rem; /* Space for the fixed navbar */
+            color: var(--color-text);
+            background-color: var(--color-bg);
+        }
+        :root {
+            --color-text: #E6E6E6;
+            --color-header: #00FF88; /* Neon Green */
+            --color-accent: #FFFFFF; /* White */
+            --color-price: #FFB454;  /* Amber */
+            --color-dim: #6B7280;
+            --color-border: #333333;
+            --shadow-glow: 0 0 8px;
+            --color-bg: #0A0A0A;
+            --window-bg: rgba(20, 20, 20, 0.9);
+            --input-bg: #1a1a1a;
+            --input-text: #ffffff;
+            --btn-text: #000000;
+            font-family: 'VT323', monospace;
+        }
+        .cli-window {
+            border: 1px solid var(--color-border);
+            border-radius: 0.375rem;
+            padding: 1rem;
+            background-color: var(--window-bg);
+            box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
+            position: relative;
+        }
+        .btn {
+            display: inline-block;
+            padding: 0.75rem 1.25rem;
+            background-color: var(--color-accent);
+            color: var(--btn-text);
+            text-shadow: none;
+            cursor: pointer;
+            border: none;
+            border-radius: 0.25rem;
+            transition: all 0.2s ease-in-out;
+        }
+        .btn:hover:not(:disabled) { background-color: var(--color-bg); color: var(--color-accent); box-shadow: 0 0 5px var(--color-accent); }
+        .btn-secondary { background-color: transparent; color: var(--color-accent); border: 1px solid var(--color-accent); border-radius: 0.25rem; transition: all 0.2s ease-in-out; }
+        .btn-secondary:hover { background-color: var(--color-accent); color: var(--btn-text); }
+        .input-field {
+            background-color: var(--input-bg);
+            border: 1px solid var(--color-border);
+            color: var(--input-text);
+            padding: 0.5rem;
+            width: 100%;
+            font-family: inherit;
+            border-radius: 0.25rem;
+        }
+        .input-field:focus { outline: none; box-shadow: 0 0 8px var(--color-accent); }
+        .text-header { color: var(--color-header); text-shadow: var(--shadow-glow) var(--color-header); }
+        .text-item-name { color: var(--color-accent); }
+        .text-price { color: var(--color-price); font-weight: bold; }
+        .text-dim { color: var(--color-dim); }
+        .border-border { border-color: var(--color-border); }
+        .custom-scrollbar::-webkit-scrollbar { width: 8px; }
+        .custom-scrollbar::-webkit-scrollbar-track { background: #1a1a1a; }
+        .custom-scrollbar::-webkit-scrollbar-thumb { background: #333333; }
+        .custom-scrollbar::-webkit-scrollbar-thumb:hover { background: #555555; }
+        .tab-button {
+            background-color: transparent;
+            border: 1px solid var(--color-border);
+            border-bottom: none;
+            padding: 0.5rem 1rem;
+            cursor: pointer;
+            transition: all 0.2s ease-in-out;
+            color: var(--color-dim);
+            border-radius: 0.375rem 0.375rem 0 0;
+        }
+        .tab-button.active {
+            background-color: var(--window-bg);
+            color: var(--color-header);
+            border-color: var(--color-header);
+            box-shadow: 0 -2px 5px rgba(0, 255, 136, 0.2);
+        }
+        .tab-content { display: none; }
+        .tab-content.active { display: block; }
+        #dm-tools-btn, #logout-btn { background: none; border: none; color: var(--color-accent); font-size: 1.25rem; cursor: pointer; }
+        #dm-tools-btn:hover, #logout-btn:hover { color: var(--color-header); text-decoration: underline; }
+        #exit-mode-btn { background: none; border: none; color: var(--color-header); font-size: 1.75rem; line-height: 1; cursor: pointer; padding: 0 0.5rem; }
+        #exit-mode-btn:hover { color: var(--color-accent); }
+    </style>
+</head>
+<body class="p-4 sm:p-6 lg:p-8">
+    <div id="toolbar" class="fixed top-0 left-0 right-0 p-4 z-50 flex justify-between items-center h-20 bg-[#0A0A0A]">
+        <div id="toolbar-title" class="text-2xl hidden text-header"></div>
+        <div id="controls-container" class="relative ml-auto flex items-center gap-4">
+             <button id="exit-mode-btn" onclick="history.back()"><i data-lucide="x" class="w-6 h-6"></i></button>
+        </div>
+    </div>
+
+    <div id="dm-view" class="max-w-7xl mx-auto">
+        <!-- This div will be populated by the renderDMView function -->
+    </div>
+
+    <script>
+        let state = {
+            shopData: {
+                shopName: "The Rusty Anvil",
+                shopType: "Blacksmith/Armory",
+                shopkeeper: { name: "Borin", description: "A gruff but fair dwarf.", gold: 1250 },
+                inventory: [
+                    { id: 'item-1', name: 'Longsword', price: 15, quantity: 3, details: 'A standard, reliable blade.' },
+                    { id: 'item-2', name: 'Studded Leather', price: 45, quantity: 2, details: 'Flexible and protective.' },
+                    { id: 'item-3', name: 'Shield', price: 10, quantity: 5, details: '' },
+                ],
+                carts: {
+                    'PLAYER1': {
+                        playerName: 'Valerius',
+                        items: [{ name: 'Longsword', price: 15 }, { name: 'Shield', price: 10 }]
+                    },
+                    'PLAYER2': {
+                        playerName: 'Elara',
+                        items: []
+                    }
+                },
+                priceModifier: 15,
+                active: true,
+            }
+        };
+
+        function getModifiedPrice(basePrice) {
+            const modifier = state.shopData?.priceModifier || 0;
+            const modified = basePrice * (1 + modifier / 100);
+            return Math.round(modified * 100) / 100;
+        }
+
+        function attachDMListeners() {
+            const tabButtons = document.querySelectorAll('.tab-button');
+            const tabContents = document.querySelectorAll('.tab-content');
+            tabButtons.forEach(button => {
+                button.addEventListener('click', () => {
+                    const tabId = button.dataset.tab;
+                    tabButtons.forEach(btn => btn.classList.remove('active'));
+                    tabContents.forEach(content => content.classList.remove('active'));
+                    button.classList.add('active');
+                    document.getElementById(tabId).classList.add('active');
+                });
+            });
+
+            document.querySelectorAll('.checkout-btn').forEach(btn => btn.addEventListener('click', (e) => console.log(`Checkout for ${e.target.dataset.playerId}`)));
+            document.querySelectorAll('.clear-cart-btn').forEach(btn => btn.addEventListener('click', (e) => console.log(`Clear cart for ${e.target.dataset.playerId}`)));
+            document.querySelectorAll('.dm-remove-item-btn').forEach(btn => btn.addEventListener('click', (e) => console.log(`Remove item at index ${e.target.dataset.index}`)));
+            document.getElementById('add-custom-item-btn')?.addEventListener('click', () => console.log('Add custom item'));
+        }
+
+        function renderDMView() {
+            const dmView = document.getElementById('dm-view');
+            const { shopkeeper, inventory, carts, shopType, priceModifier, shopName, active } = state.shopData;
+            dmView.innerHTML = `
+                <header class="cli-window mb-4">
+                    <h1 class="text-3xl text-header">${shopName}</h1>
+                    <p class="text-xl text-dim">(${shopType})</p>
+                    <p class="mt-2">> Status: <span class="${active ? 'text-header' : 'text-price'}">${active ? 'Active' : 'Inactive'}</span></p>
+                </header>
+                <nav class="flex items-end -mb-px lg:hidden">
+                    <button class="tab-button active" data-tab="controls-inventory">
+                        <i data-lucide="sliders-horizontal" class="inline-block w-4 h-4 mr-1"></i> Controls & Inventory
+                    </button>
+                    <button class="tab-button" data-tab="player-carts">
+                        <i data-lucide="shopping-cart" class="inline-block w-4 h-4 mr-1"></i> Player Carts
+                    </button>
+                </nav>
+                <div class="lg:grid lg:grid-cols-3 lg:gap-6">
+                    <div id="controls-inventory" class="tab-content active lg:col-span-2 lg:block">
+                        <div class="lg:grid lg:grid-cols-2 lg:gap-6">
+                            <div class="cli-window mb-6 lg:mb-0">
+                                <h2 class="text-2xl mb-4 text-header">> DM Controls</h2>
+                                <div class="space-y-4">
+                                    <div>
+                                        <label class="block mb-1">> Price Modifier: <span class="text-accent">${priceModifier}%</span></label>
+                                        <div class="grid grid-cols-3 gap-2">
+                                            ${[-50,-25,-15,15,25,50].map(v => `<button class="${priceModifier===v?'btn':'btn-secondary'} !p-2" data-value="${v}">${v>0?`+${v}`:v}%</button>`).join('')}
+                                        </div>
+                                    </div>
+                                    <div>
+                                        <h3 class="text-xl text-accent">> Shopkeeper: ${shopkeeper.name}</h3>
+                                        <div class="flex items-center gap-2 mt-1">
+                                            <p class="whitespace-nowrap">> Gold:</p>
+                                            <input type="number" value="${shopkeeper.gold}" class="input-field text-price">
+                                        </div>
+                                    </div>
+                                    <div class="grid grid-cols-2 gap-2 pt-2">
+                                        <button class="btn-secondary">${active ? 'Set Inactive' : 'Set Active'}</button>
+                                        <button class="btn-secondary text-red-500 border-red-500 hover:bg-red-500 hover:text-white">Delete Shop</button>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="cli-window">
+                                <h2 class="text-2xl mb-4 text-header">> Add Item</h2>
+                                <div class="space-y-2">
+                                    <input id="custom-item-name" class="input-field" placeholder="Item Name">
+                                    <textarea id="custom-item-details" class="input-field h-20" placeholder="Details (optional)"></textarea>
+                                    <div class="flex gap-2">
+                                        <input id="custom-item-price" type="number" class="input-field" placeholder="Price">
+                                        <input id="custom-item-qty" type="number" class="input-field" placeholder="Qty">
+                                    </div>
+                                    <button id="add-custom-item-btn" class="btn w-full">Add Item</button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="cli-window mt-6">
+                            <h2 class="text-2xl mb-4 text-header">> Shop Inventory (${inventory.length})</h2>
+                            <div id="dm-inventory-list" class="space-y-4 max-h-[60vh] overflow-y-auto custom-scrollbar pr-2">
+                                ${inventory.map((item, index) => `
+                                    <div class="border border-border p-3 rounded-lg space-y-2" data-index="${index}">
+                                        <div class="flex justify-between items-start">
+                                            <p class="text-xl text-item-name">${item.name}</p>
+                                            <button class="text-red-500 hover:text-red-400 dm-remove-item-btn" data-index="${index}"><i data-lucide="trash-2" class="w-5 h-5"></i></button>
+                                        </div>
+                                        <textarea class="input-field text-sm" placeholder="Details">${item.details || ''}</textarea>
+                                        <div class="flex items-center gap-2 flex-wrap">
+                                            <label class="text-dim">Qty:</label>
+                                            <input type="number" min="0" class="input-field w-20" value="${item.quantity}">
+                                            <label class="text-dim ml-auto">Price:</label>
+                                            <input type="number" min="0" step="0.01" class="input-field w-24 text-price" value="${item.price}">
+                                        </div>
+                                    </div>
+                                `).join('')}
+                            </div>
+                        </div>
+                    </div>
+                    <div id="player-carts" class="tab-content lg:col-span-1 lg:block">
+                         <div class="cli-window">
+                            <h2 class="text-2xl mb-4 text-header">> Player Carts</h2>
+                            <div id="player-carts-list" class="space-y-4 max-h-[80vh] overflow-y-auto custom-scrollbar pr-2">
+                                ${Object.keys(carts || {}).length === 0 ? '<p class="text-dim">No active carts.</p>' : Object.entries(carts).map(([playerId, cartData]) => `
+                                    <div class="border-b border-border pb-3">
+                                        <h3 class="text-xl text-header">${cartData.playerName}</h3>
+                                        ${cartData.items.length > 0 ? `
+                                            <ul class="pl-4 list-disc list-inside text-dim my-2">
+                                                ${cartData.items.map(item => `<li><span class="text-item-name">${item.name}</span></li>`).join('')}
+                                            </ul>
+                                            <p class="mt-2 text-right">> Cart Total: <span class="text-price">${cartData.items.reduce((sum, item) => sum + getModifiedPrice(item.price), 0)} GP</span></p>
+                                            <div class="grid grid-cols-2 gap-2 mt-3">
+                                                <button class="btn checkout-btn" data-player-id="${playerId}">Checkout</button>
+                                                <button class="btn-secondary clear-cart-btn" data-player-id="${playerId}">Clear Cart</button>
+                                            </div>
+                                        ` : `
+                                            <p class="text-dim my-2">Cart is empty.</p>
+                                            <div class="mt-3">
+                                                <button class="btn-secondary clear-cart-btn w-full" data-player-id="${playerId}">Remove Cart</button>
+                                            </div>
+                                        `}
+                                    </div>
+                                `).join('')}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            `;
+            lucide.createIcons();
+            attachDMListeners();
+        }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            renderDMView();
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Introduce `dm-shop.html` to provide a Dungeon Master shop interface.
- Reuse the existing top toolbar for consistent navigation.
- Include controls for price modifiers, shopkeeper gold, inventory editing, and player cart management.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a112d7b8e0832aa8b39fa88d009641