### PR TITLE
Optimize spell slot updates to prevent flicker

### DIFF
--- a/character.html
+++ b/character.html
@@ -392,22 +392,35 @@
             }
         }
 
+        function updateSlotsForLevel(level) {
+            const { max, expended } = state.spellSlots[level];
+            const container = document.getElementById('spell-slots-container');
+            const slots = container.querySelectorAll(`.slot[data-level="${level}"]`);
+            slots.forEach((slot, i) => {
+                const isAvailable = i < (max - expended);
+                slot.classList.toggle('slot-available', isAvailable);
+                slot.classList.toggle('slot-expended', !isAvailable);
+            });
+        }
+
         function renderSpellSlots() {
             const container = document.getElementById('spell-slots-container');
-            container.innerHTML = '';
-            for (const level in state.spellSlots) {
-                const { max, expended } = state.spellSlots[level];
-                let slotsHtml = '';
-                for (let i = 0; i < max; i++) {
-                    const isAvailable = i < (max - expended);
-                    slotsHtml += `<div class="slot-segment ${isAvailable ? 'slot-available' : 'slot-expended'}" data-level="${level}" data-index="${i}"></div>`;
+            if (!container.innerHTML) {
+                let html = '';
+                for (const level in state.spellSlots) {
+                    const { max } = state.spellSlots[level];
+                    html += `<div class="flex items-center justify-start gap-4" data-level-bar="${level}">`;
+                    html += `<span class="text-accent w-20">Lvl ${level}</span><div class="slot-bar">`;
+                    for (let i = 0; i < max; i++) {
+                        html += `<div class="slot-segment slot" data-level="${level}" data-index="${i}"></div>`;
+                    }
+                    html += `</div></div>`;
                 }
-                container.innerHTML += `
-                    <div class="flex items-center justify-start gap-4">
-                        <span class="text-accent w-20">Lvl ${level}</span>
-                        <div class="slot-bar">${slotsHtml}</div>
-                    </div>
-                `;
+                container.innerHTML = html;
+            }
+
+            for (const level in state.spellSlots) {
+                updateSlotsForLevel(level);
             }
         }
 
@@ -458,7 +471,7 @@
             if (!slot || slot.expended >= slot.max) return;
             slot.expended++;
             saveSpellSlots();
-            renderSpellSlots();
+            updateSlotsForLevel(level);
         }
 
         function handleSlotClick(e) {
@@ -475,13 +488,15 @@
                 slot.expended = maxSlots - (index + 1);
             }
             saveSpellSlots();
-            renderSpellSlots();
+            updateSlotsForLevel(level);
         }
 
         function handleLongRest() {
-            Object.values(state.spellSlots).forEach(s => s.expended = 0);
+            Object.keys(state.spellSlots).forEach(level => {
+                state.spellSlots[level].expended = 0;
+                updateSlotsForLevel(level);
+            });
             saveSpellSlots();
-            renderSpellSlots();
         }
 
         document.getElementById('spell-slots-container').addEventListener('click', handleSlotClick);

--- a/spells.html
+++ b/spells.html
@@ -235,28 +235,35 @@
             renderSpellSlots();
         }
 
+        function updateSlotsForLevel(level) {
+            const { max, expended } = state.spellSlots[level];
+            const container = document.getElementById('spell-slots-container');
+            const slots = container.querySelectorAll(`.slot[data-level="${level}"]`);
+            slots.forEach((slot, i) => {
+                const isAvailable = i < (max - expended);
+                slot.classList.toggle('slot-available', isAvailable);
+                slot.classList.toggle('slot-expended', !isAvailable);
+            });
+        }
+
         function renderSpellSlots() {
             const container = document.getElementById('spell-slots-container');
-            container.innerHTML = '';
-            if (Object.keys(state.spellSlots).length === 0) {
-                 container.innerHTML = '<p class="text-dim">> No spell slots.</p>';
-                 return;
-            }
-            for (const level in state.spellSlots) {
-                const levelData = state.spellSlots[level];
-                let slotsHtml = '';
-                for (let i = 0; i < levelData.max; i++) {
-                    // Right-to-left logic: A slot is available if its index is less than the number of available slots.
-                    const isAvailable = i < (levelData.max - levelData.expended);
-                    const slotClass = isAvailable ? 'slot-available' : 'slot-expended';
-                    slotsHtml += `<div class="slot-segment ${slotClass} slot" data-level="${level}" data-index="${i}"></div>`;
+            if (!container.innerHTML) {
+                let html = '';
+                for (const level in state.spellSlots) {
+                    html += `<div class="flex items-center justify-start gap-4" data-level-bar="${level}">`;
+                    html += `<span class="text-item-name w-20">Level ${level}</span><div class="slot-bar">`;
+                    const { max } = state.spellSlots[level];
+                    for (let i = 0; i < max; i++) {
+                        html += `<div class="slot-segment slot" data-level="${level}" data-index="${i}"></div>`;
+                    }
+                    html += `</div></div>`;
                 }
-                container.innerHTML += `
-                    <div class="flex items-center justify-start gap-4">
-                        <span class="text-item-name w-20">Level ${level}</span>
-                        <div class="slot-bar">${slotsHtml}</div>
-                    </div>
-                `;
+                container.innerHTML = html;
+            }
+
+            for (const level in state.spellSlots) {
+                updateSlotsForLevel(level);
             }
         }
 
@@ -398,7 +405,7 @@
             const levelStr = String(spellLevelToUse);
             if (state.spellSlots[levelStr] && state.spellSlots[levelStr].expended < state.spellSlots[levelStr].max) {
                 state.spellSlots[levelStr].expended++;
-                renderSpellSlots();
+                updateSlotsForLevel(levelStr);
             } else {
                 const originalText = button.textContent;
                 button.textContent = "No Slots!";
@@ -417,7 +424,7 @@
             const levelData = state.spellSlots[level];
             const maxSlots = levelData.max;
             const currentAvailable = maxSlots - levelData.expended;
-            
+
             // Right-to-left toggle logic
             if (currentAvailable === index + 1) {
                 // Clicking the rightmost available slot, expend it
@@ -426,14 +433,14 @@
                 // Clicking an expended slot or a non-rightmost available one, set the boundary
                 levelData.expended = maxSlots - (index + 1);
             }
-            renderSpellSlots();
+            updateSlotsForLevel(level);
         }
-        
+
         function handleLongRest() {
             for (const level in state.spellSlots) {
                 state.spellSlots[level].expended = 0;
+                updateSlotsForLevel(level);
             }
-            renderSpellSlots();
             renderPreparedSpells(); // Rerender to show all cast buttons again
         }
 


### PR DESCRIPTION
## Summary
- Avoid rebuilding entire spell slot blocks by updating individual slot elements
- Streamline spell casting and rest handlers to touch only the affected slots

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a11555799c832a868b3e5c0ed2bb3d