### PR TITLE
Keep spell slot data in sync between character sheet and player hub

### DIFF
--- a/character.html
+++ b/character.html
@@ -383,6 +383,7 @@
             if (!characterKey) return;
             try {
                 await updateDoc(doc(db, 'characters', characterKey), { spellSlots: state.spellSlots });
+                try { localStorage.setItem('spellSlots', JSON.stringify(state.spellSlots)); } catch {}
                 if (playerData) {
                     playerData.spellSlots = state.spellSlots;
                     sessionStorage.setItem('currentPlayer', JSON.stringify(playerData));

--- a/index.html
+++ b/index.html
@@ -549,11 +549,18 @@
                 const slotsPrev = prev?.spellSlots || {};
                 const slotsNext = next?.spellSlots || {};
                 const slotsChanged = JSON.stringify(slotsPrev) !== JSON.stringify(slotsNext);
+                if (slotsChanged) {
+                    try { localStorage.setItem('spellSlots', JSON.stringify(slotsNext)); } catch {}
+                }
                 const onlySlotsChanged = restEqual && slotsChanged;
 
                 // If it's our own write echo, or only slots changed, do minimal update
                 if (suppressRender || onlySlotsChanged) {
                     updateSpellSlotsUI(slotsNext);
+                    if (state.spellState) {
+                        state.spellState.spellSlots = slotsNext;
+                        try { localStorage.setItem('spellSlots', JSON.stringify(slotsNext)); } catch {}
+                    }
                     return; // skip full render to prevent flashing
                 }
 
@@ -1121,6 +1128,9 @@ async function handleDMActiveChange(e) {
 
             const savedSlots = localStorage.getItem('spellSlots');
             if (savedSlots) { try { spellState.spellSlots = JSON.parse(savedSlots); } catch {} }
+
+            // expose for external updates (e.g., Firestore listeners)
+            state.spellState = spellState;
 
             async function saveSpellSlots() {
                 try {


### PR DESCRIPTION
## Summary
- Persist character sheet spell slot updates to local storage
- Expose spell slot state to the hub and keep it synced with Firestore updates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a124f1f110832a92e6e30d2d233e5f