### PR TITLE
Improve DM tools layout and shop pricing controls

### DIFF
--- a/dm-shop.html
+++ b/dm-shop.html
@@ -115,7 +115,7 @@
 
     <script type="module">
         import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
-        import { getFirestore, doc, onSnapshot } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+        import { getFirestore, doc, onSnapshot, runTransaction, updateDoc, deleteField } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
 
         const firebaseConfig = {
           apiKey: "AIzaSyA4KsHgYxihH0fgsSET1kcnONHxtlInZIE",
@@ -143,6 +143,62 @@
             return Math.round(modified * 100) / 100;
         }
 
+        async function handleCheckout(e) {
+            const playerId = e.target.dataset.playerId;
+            const shopDocRef = doc(db, 'shops', shopId);
+            const playerDocRef = doc(db, 'characters', playerId);
+            try {
+                await runTransaction(db, async (transaction) => {
+                    const shopDoc = await transaction.get(shopDocRef);
+                    const playerDoc = await transaction.get(playerDocRef);
+                    if (!shopDoc.exists() || !playerDoc.exists()) throw 'Document not found!';
+                    const shopData = shopDoc.data();
+                    const playerData = playerDoc.data();
+                    const cart = shopData.carts[playerId];
+                    if (!cart || cart.items.length === 0) return;
+                    const totalCost = cart.items.reduce((sum, item) => sum + getModifiedPrice(item.price), 0);
+                    if (playerData.gold < totalCost) throw `${playerData.name} doesn't have enough gold!`;
+                    transaction.update(shopDocRef, {
+                        'shopkeeper.gold': shopData.shopkeeper.gold + totalCost,
+                        [`carts.${playerId}`]: { items: [] }
+                    });
+                    transaction.update(playerDocRef, {
+                        gold: playerData.gold - totalCost,
+                        inventory: [...playerData.inventory, ...cart.items]
+                    });
+                });
+            } catch (error) {
+                console.error('Checkout failed:', error);
+                alert(`Checkout failed: ${error}`);
+            }
+        }
+
+        async function handleClearCart(e) {
+            const playerId = e.target.dataset.playerId;
+            const shopRef = doc(db, 'shops', shopId);
+            try {
+                await runTransaction(db, async (transaction) => {
+                    const shopDoc = await transaction.get(shopRef);
+                    if (!shopDoc.exists()) throw 'Shop not found';
+                    const shopData = shopDoc.data();
+                    const cart = shopData.carts[playerId];
+                    if (!cart) return;
+                    const newInventory = [...shopData.inventory];
+                    cart.items.forEach(it => {
+                        const idx = newInventory.findIndex(inv => inv.id === it.id);
+                        if (idx !== -1) {
+                            newInventory[idx] = { ...newInventory[idx], quantity: newInventory[idx].quantity + 1 };
+                        }
+                    });
+                    const updates = { inventory: newInventory };
+                    updates[`carts.${playerId}`] = deleteField();
+                    transaction.update(shopRef, updates);
+                });
+            } catch (err) {
+                console.error('Clear cart failed:', err);
+            }
+        }
+
         function attachDMListeners() {
             const tabButtons = document.querySelectorAll('.tab-button');
             const tabContents = document.querySelectorAll('.tab-content');
@@ -156,10 +212,15 @@
                 });
             });
 
-            document.querySelectorAll('.checkout-btn').forEach(btn => btn.addEventListener('click', (e) => console.log(`Checkout for ${e.target.dataset.playerId}`)));
-            document.querySelectorAll('.clear-cart-btn').forEach(btn => btn.addEventListener('click', (e) => console.log(`Clear cart for ${e.target.dataset.playerId}`)));
-            document.querySelectorAll('.dm-remove-item-btn').forEach(btn => btn.addEventListener('click', (e) => console.log(`Remove item at index ${e.target.dataset.index}`)));
-            document.getElementById('add-custom-item-btn')?.addEventListener('click', () => console.log('Add custom item'));
+            document.querySelectorAll('.checkout-btn').forEach(btn => btn.addEventListener('click', handleCheckout));
+            document.querySelectorAll('.clear-cart-btn').forEach(btn => btn.addEventListener('click', handleClearCart));
+            document.querySelectorAll('.price-mod-btn').forEach(btn => btn.addEventListener('click', (e) => {
+                const value = parseInt(e.currentTarget.dataset.value, 10);
+                const newVal = state.shopData.priceModifier === value ? 0 : value;
+                state.shopData.priceModifier = newVal;
+                renderDMView();
+                updateDoc(doc(db, 'shops', shopId), { priceModifier: newVal });
+            }));
         }
 
         function renderDMView() {
@@ -188,7 +249,7 @@
                                     <div>
                                         <label class="block mb-1">> Price Modifier: <span class="text-accent">${priceModifier}%</span></label>
                                         <div class="grid grid-cols-3 gap-2">
-                                            ${[-50,-25,-15,15,25,50].map(v => `<button class="${priceModifier===v?'btn':'btn-secondary'} !p-2" data-value="${v}">${v>0?`+${v}`:v}%</button>`).join('')}
+                                            ${[-50,-25,-15,15,25,50].map(v => `<button class="${priceModifier===v?'btn':'btn-secondary'} price-mod-btn !p-2" data-value="${v}">${v>0?`+${v}`:v}%</button>`).join('')}
                                         </div>
                                     </div>
                                     <div>
@@ -232,6 +293,7 @@
                                             <input type="number" min="0" class="input-field w-20" value="${item.quantity}">
                                             <label class="text-dim ml-auto">Price:</label>
                                             <input type="number" min="0" step="0.01" class="input-field w-24 text-price" value="${item.price}">
+        <span class="text-dim ml-2">=</span><span class="text-price">${getModifiedPrice(item.price)} GP</span>
                                         </div>
                                     </div>
                                 `).join('')}
@@ -247,7 +309,7 @@
                                         <h3 class="text-xl text-header">${cartData.playerName}</h3>
                                         ${cartData.items.length > 0 ? `
                                             <ul class="pl-4 list-disc list-inside text-dim my-2">
-                                                ${cartData.items.map(item => `<li><span class="text-item-name">${item.name}</span></li>`).join('')}
+                                                ${cartData.items.map(item => `<li><span class="text-item-name">${item.name}</span> - <span class="text-price">${getModifiedPrice(item.price)} GP</span></li>`).join('')}
                                             </ul>
                                             <p class="mt-2 text-right">> Cart Total: <span class="text-price">${cartData.items.reduce((sum, item) => sum + getModifiedPrice(item.price), 0)} GP</span></p>
                                             <div class="grid grid-cols-2 gap-2 mt-3">

--- a/index.html
+++ b/index.html
@@ -1061,39 +1061,57 @@
 
         function renderDMHub() {
             dmHubView.innerHTML = `
-                <div class="cli-window max-w-md mx-auto">
-                    <h2 class="text-2xl mb-4 text-header">> DM Tools</h2>
-                    <div class="space-y-2">
-                        <button id="dm-create-character-btn" type="button" class="btn w-full">Create New Character</button>
-                        <button id="dm-manage-players-btn" class="btn w-full">Manage Players</button>
+        <div id="dm-hub-view" class="max-w-4xl mx-auto">
+            <header class="text-center mb-8">
+                <h1 class="text-4xl text-header">&gt; DM Hub</h1>
+                <p class="text-lg text-dim">Manage your game world.</p>
+            </header>
+            <main class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div class="dashboard-card">
+                    <div class="flex items-center gap-3 mb-4">
+                        <i data-lucide="swords" class="w-8 h-8 text-header"></i>
+                        <h2 class="text-2xl text-header">&gt; DM Actions</h2>
+                    </div>
+                    <p class="text-dim mb-4 flex-grow">Create new characters for your players or manage existing ones.</p>
+                    <div class="space-y-3 mt-auto">
+                        <button id="dm-create-character-btn" class="btn w-full">Create New Character</button>
+                        <button id="dm-manage-players-btn" class="btn-secondary w-full">Manage Players</button>
                     </div>
                 </div>
-                <div class="mt-8 cli-window max-w-md mx-auto">
-                    <h2 class="text-2xl mb-4 text-header">> Your Shops</h2>
-                    <div class="space-y-2">
-                        <button id="dm-create-shop-btn" class="btn w-full">Create New Shop</button>
-                        <div class="border-t border-border my-2"></div>
-                        ${state.dmShops.length === 0
-                            ? '<p class="text-dim">No shops.</p>'
-                            : state.dmShops.map(s => `
-                                <div class="flex items-center mb-2 gap-2">
-                                    <button class="btn flex-1 text-left dm-enter-shop-btn" data-shop-id="${s.id}">${s.shopName || s.shopType}</button>
-                                    <input type="checkbox" class="dm-active-checkbox" data-shop-id="${s.id}" ${s.active ? 'checked' : ''}>
-                                    <button class="text-red-500 hover:text-red-400 dm-delete-shop-btn" data-shop-id="${s.id}">X</button>
+                <div class="dashboard-card">
+                    <div class="flex items-center gap-3 mb-4">
+                        <i data-lucide="store" class="w-8 h-8 text-header"></i>
+                        <h2 class="text-2xl text-header">&gt; Your Shops</h2>
+                    </div>
+                    <div id="dm-shops-list" class="space-y-3 flex-grow mb-4">
+                        ${state.dmShops.length === 0 ? '<p class="text-dim">No shops created yet.</p>' : state.dmShops.map(shop => `
+                            <div class="flex items-center justify-between p-2 border-b border-border">
+                                <span class="text-accent">${shop.shopName || shop.shopType}</span>
+                                <div class="flex items-center gap-3">
+                                    <span class="text-xs ${shop.active ? 'text-header' : 'text-dim'}">${shop.active ? 'Active' : 'Inactive'}</span>
+                                    <button class="btn-secondary !p-2 text-sm dm-enter-shop-btn" data-shop-id="${shop.id}" title="Enter Shop">
+                                        <i data-lucide="log-in" class="w-4 h-4"></i>
+                                    </button>
+                                    <button class="text-red-500 hover:text-red-400 dm-delete-shop-btn" data-shop-id="${shop.id}" title="Delete Shop">
+                                        <i data-lucide="trash-2" class="w-4 h-4"></i>
+                                    </button>
                                 </div>
-                            `).join('')}
+                            </div>
+                        `).join('')}
                     </div>
+                    <button id="dm-create-shop-btn" class="btn w-full mt-auto">Create New Shop</button>
                 </div>
+            </main>
+        </div>
             `;
+            lucide.createIcons();
             document.getElementById('dm-create-shop-btn').addEventListener('click', showCreateShopView);
             document.getElementById('dm-create-character-btn').addEventListener('click', handleCreateCharacter);
             document.getElementById('dm-manage-players-btn').addEventListener('click', openPlayersModal);
             document.querySelectorAll('.dm-enter-shop-btn').forEach(btn => {
-                btn.addEventListener('click', e => joinShop(e.target.dataset.shopId));
+                btn.addEventListener('click', e => joinShop(e.currentTarget.dataset.shopId));
             });
             document.querySelectorAll('.dm-delete-shop-btn').forEach(btn => btn.addEventListener('click', handleDMDeleteShop));
-            document.querySelectorAll('.dm-active-checkbox').forEach(cb => cb.addEventListener('change', handleDMActiveChange));
-
         }
 
         async function handleDMDeleteShop(e) {


### PR DESCRIPTION
## Summary
- Replace DM tools hub with new dashboard layout showing DM actions and shops
- Enable checkout and clear cart actions in DM shop
- Apply togglable price modifiers across inventory and carts with updated UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a128252c28832a853e1be6e8d98fe1