### PR TITLE
Scroll pages to top on load

### DIFF
--- a/character.html
+++ b/character.html
@@ -110,6 +110,14 @@
     </style>
 </head>
 <body class="p-4 sm:p-6 lg:p-8">
+    <script>
+        if ('scrollRestoration' in history) {
+            history.scrollRestoration = 'manual';
+        }
+        window.addEventListener('load', () => {
+            window.scrollTo(0, 0);
+        });
+    </script>
 
     <!-- Top Navigation -->
     <div id="toolbar" class="fixed top-0 left-0 right-0 p-4 z-50 flex justify-between items-center h-20 bg-[#0A0A0A]">

--- a/dm-shop.html
+++ b/dm-shop.html
@@ -100,6 +100,14 @@
     </style>
 </head>
 <body class="p-4 sm:p-6 lg:p-8">
+    <script>
+        if ('scrollRestoration' in history) {
+            history.scrollRestoration = 'manual';
+        }
+        window.addEventListener('load', () => {
+            window.scrollTo(0, 0);
+        });
+    </script>
     <div id="toolbar" class="fixed top-0 left-0 right-0 p-4 z-50 flex justify-between items-center h-20 bg-[#0A0A0A]">
         <div id="toolbar-title" class="text-2xl hidden text-header"></div>
         <div id="controls-container" class="relative ml-auto flex items-center gap-4">

--- a/index.html
+++ b/index.html
@@ -146,6 +146,14 @@
     </style>
 </head>
 <body class="p-4 sm:p-6 lg:p-8 cli-theme">
+    <script>
+        if ('scrollRestoration' in history) {
+            history.scrollRestoration = 'manual';
+        }
+        window.addEventListener('load', () => {
+            window.scrollTo(0, 0);
+        });
+    </script>
 
     <div id="toolbar" class="fixed top-0 left-0 right-0 p-4 z-50 flex justify-between items-center h-20 bg-[#0A0A0A]">
         <div id="toolbar-title" class="text-2xl hidden text-header"></div>

--- a/spells.html
+++ b/spells.html
@@ -119,6 +119,14 @@
     </style>
 </head>
 <body class="p-4 sm:p-6 lg:p-8">
+    <script>
+        if ('scrollRestoration' in history) {
+            history.scrollRestoration = 'manual';
+        }
+        window.addEventListener('load', () => {
+            window.scrollTo(0, 0);
+        });
+    </script>
 
     <div id="toolbar" class="fixed top-0 left-0 right-0 p-4 z-50 flex justify-between items-center h-20 bg-[#0A0A0A]">
         <div id="toolbar-title" class="text-2xl hidden text-header"></div>


### PR DESCRIPTION
## Summary
- Force pages to start at the top by resetting scroll position on load
- Disable browser scroll restoration to prevent returning to mid-page positions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a12acd1e38832a9fcd6ecaf4ac577f