### PR TITLE
Load spell data from character JSON

### DIFF
--- a/character.html
+++ b/character.html
@@ -137,27 +137,27 @@
                 <div class="flex items-center gap-4 flex-1">
                     <img id="char-avatar" src="https://i.imgur.com/zLRhJXx.png" alt="Character Avatar" class="w-24 h-24 object-cover rounded-full border-2 border-header">
                     <div>
-                        <h1 id="char-name" class="text-3xl text-header">Elara Meadowlight</h1>
-                        <p id="char-classlevel" class="text-lg text-dim">Level 5 Wizard</p>
+                        <h1 id="char-name" class="text-3xl text-header"></h1>
+                        <p id="char-classlevel" class="text-lg text-dim"></p>
                     </div>
                 </div>
                 <!-- Core Stats -->
                 <div class="grid grid-cols-4 gap-3 text-center text-lg w-full sm:w-auto">
                     <div class="content-card !p-2 flex flex-col items-center">
                         <span class="text-dim text-sm">HP</span>
-                        <span id="stat-hp" class="text-2xl text-accent">28/35</span>
+                        <span id="stat-hp" class="text-2xl text-accent"></span>
                     </div>
                     <div class="content-card !p-2 flex flex-col items-center">
                         <span class="text-dim text-sm">AC</span>
-                        <span id="stat-ac" class="text-2xl text-accent">13</span>
+                        <span id="stat-ac" class="text-2xl text-accent"></span>
                     </div>
                     <div class="content-card !p-2 flex flex-col items-center">
                         <span class="text-dim text-sm">Speed</span>
-                        <span id="stat-speed" class="text-2xl text-accent">30ft</span>
+                        <span id="stat-speed" class="text-2xl text-accent"></span>
                     </div>
                     <div class="content-card !p-2 flex flex-col items-center">
                         <span class="text-dim text-sm">Init</span>
-                        <span id="stat-init" class="text-2xl text-accent">+2</span>
+                        <span id="stat-init" class="text-2xl text-accent"></span>
                     </div>
                 </div>
             </div>
@@ -348,11 +348,12 @@
                 playerData = JSON.parse(playerDataString);
                 const sheet = playerData.sheet || {};
                 renderCharacter(sheet, playerData);
+                initSpellData(sheet);
             } catch {
-                fetch('sample-character.json').then(r => r.json()).then(data => renderCharacter(data));
+                fetch('sample-character.json').then(r => r.json()).then(data => { renderCharacter(data); initSpellData(data); });
             }
         } else {
-            fetch('sample-character.json').then(r => r.json()).then(data => renderCharacter(data));
+            fetch('sample-character.json').then(r => r.json()).then(data => { renderCharacter(data); initSpellData(data); });
         }
 
         // Initialize Lucide Icons
@@ -374,12 +375,9 @@
 
         // Spell state and rendering
         const state = {
-            preparedSpells: [
-                { name: 'Fire Bolt', level: 0 },
-                { name: 'Magic Missile', level: 1 },
-                { name: 'Shield', level: 1 }
-            ],
-            spellSlots: (playerData && playerData.spellSlots) || {
+            knownSpells: [],
+            preparedSpells: [],
+            spellSlots: (playerData && playerData.sheet && playerData.sheet.spellcasting && playerData.sheet.spellcasting.spellSlots) || {
                 1: { max: 4, expended: 0 },
                 2: { max: 3, expended: 0 },
                 3: { max: 2, expended: 0 },
@@ -387,13 +385,44 @@
             }
         };
 
+        const API_BASE = "https://www.dnd5eapi.co/api";
+        function toIndex(name) {
+            return name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+        }
+        async function getSpellDetails(index) {
+            try {
+                const res = await fetch(`${API_BASE}/spells/${index}`);
+                if (!res.ok) throw new Error('Spell fetch failed');
+                return await res.json();
+            } catch (err) {
+                console.error('Spell fetch error', err);
+                return null;
+            }
+        }
+
+        async function initSpellData(sheet) {
+            const sc = (sheet && sheet.spellcasting) || {};
+            state.spellSlots = sc.spellSlots || state.spellSlots;
+            const knownNames = sc.knownSpells || [];
+            const preparedNames = sc.preparedSpells || [];
+            const spellPromises = knownNames.map(name => getSpellDetails(toIndex(name)));
+            state.knownSpells = (await Promise.all(spellPromises)).filter(Boolean);
+            state.preparedSpells = preparedNames
+                .map(name => state.knownSpells.find(s => s.name === name))
+                .filter(Boolean);
+            renderSpellSlots();
+            renderPreparedSpells();
+        }
+
         async function saveSpellSlots() {
             if (!characterKey) return;
             try {
-                await updateDoc(doc(db, 'characters', characterKey), { spellSlots: state.spellSlots });
+                await updateDoc(doc(db, 'characters', characterKey), { 'sheet.spellcasting.spellSlots': state.spellSlots });
                 try { localStorage.setItem('spellSlots', JSON.stringify(state.spellSlots)); } catch {}
                 if (playerData) {
-                    playerData.spellSlots = state.spellSlots;
+                    playerData.sheet = playerData.sheet || {};
+                    playerData.sheet.spellcasting = playerData.sheet.spellcasting || {};
+                    playerData.sheet.spellcasting.spellSlots = state.spellSlots;
                     sessionStorage.setItem('currentPlayer', JSON.stringify(playerData));
                 }
             } catch (err) {
@@ -514,18 +543,14 @@
         });
         document.getElementById('long-rest-btn').addEventListener('click', handleLongRest);
 
-        renderPreparedSpells();
-        renderSpellSlots();
-
         // Listen for remote updates
         if (characterKey) {
             const playerDocRef = doc(db, 'characters', characterKey);
             onSnapshot(playerDocRef, (docSnap) => {
                 if (docSnap.exists()) {
                     playerData = docSnap.data();
-                    state.spellSlots = playerData.spellSlots || state.spellSlots;
                     renderCharacter(playerData.sheet || {}, playerData);
-                    renderSpellSlots();
+                    initSpellData(playerData.sheet || {});
                 }
             });
         }

--- a/index.html
+++ b/index.html
@@ -1143,8 +1143,8 @@ async function handleDMActiveChange(e) {
 
             const spellState = {
                 knownSpells: [],
-                preparedSpells: ["Magic Missile", "Shield"],
-                spellSlots: state.playerData.spellSlots || {
+                preparedSpells: [],
+                spellSlots: (state.playerData.sheet && state.playerData.sheet.spellcasting && state.playerData.sheet.spellcasting.spellSlots) || {
                     '1': { max: 4, expended: 0 },
                     '2': { max: 3, expended: 0 },
                     '3': { max: 2, expended: 0 },
@@ -1158,9 +1158,31 @@ async function handleDMActiveChange(e) {
             // expose for external updates (e.g., Firestore listeners)
             state.spellState = spellState;
 
+            function toIndex(name) {
+                return name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+            }
+
+            async function saveSpellcasting() {
+                const spellcasting = {
+                    spellSlots: spellState.spellSlots,
+                    knownSpells: spellState.knownSpells.map(s => s.name),
+                    preparedSpells: spellState.preparedSpells
+                };
+                state.playerData.sheet = state.playerData.sheet || {};
+                state.playerData.sheet.spellcasting = spellcasting;
+                sessionStorage.setItem('currentPlayer', JSON.stringify(state.playerData));
+                if (state.characterKey) {
+                    try {
+                        await updateDoc(doc(db, 'characters', state.characterKey), { 'sheet.spellcasting': spellcasting });
+                    } catch (err) {
+                        console.error('Error saving spellcasting:', err);
+                    }
+                }
+            }
+
             async function saveSpellSlots() {
                 try {
-                    window.saveSpellSlotsDebounced(spellState.spellSlots);
+                    await saveSpellcasting();
                 } catch (err) {
                     console.error('Error saving spell slots:', err);
                 }
@@ -1195,14 +1217,16 @@ async function handleDMActiveChange(e) {
                 }
             }
 
-            async function loadInitialSpells() {
-                const initialSpellIndexes = ['magic-missile', 'shield', 'fireball', 'light'];
-                const spellPromises = initialSpellIndexes.map(index => getSpellDetails(index));
+            (async () => {
+                const sc = (state.playerData.sheet && state.playerData.sheet.spellcasting) || {};
+                spellState.preparedSpells = sc.preparedSpells || [];
+                const knownNames = sc.knownSpells || [];
+                const spellPromises = knownNames.map(name => getSpellDetails(toIndex(name)));
                 spellState.knownSpells = (await Promise.all(spellPromises)).filter(Boolean);
                 renderSpellbook();
                 renderPreparedSpells();
                 renderSpellSlots();
-            }
+            })();
 
             function renderSpellSlots() {
                 const container = module.querySelector('#spell-slots-container');
@@ -1338,6 +1362,7 @@ async function handleDMActiveChange(e) {
                     renderSpellbook();
                     const query = module.querySelector('#search-input').value.trim();
                     if (query) searchSpellsAPI(query);
+                    await saveSpellcasting();
                 }
             }
 
@@ -1352,6 +1377,7 @@ async function handleDMActiveChange(e) {
                 }
                 renderPreparedSpells();
                 renderSpellbook();
+                saveSpellcasting();
             }
 
             function handleCastSpell(e) {
@@ -1431,8 +1457,6 @@ async function handleDMActiveChange(e) {
                 renderPreparedSpells();
                 renderSpellSlots();
             });
-
-            loadInitialSpells();
         }
 
 function getModifiedPrice(basePrice) {

--- a/sample-character.json
+++ b/sample-character.json
@@ -64,10 +64,17 @@
     "money": { "cp": 0, "sp": 0, "ep": 0, "gp": 0, "pp": 0 },
     "list": "Item list"
   },
-  "spellSlots": {
-    "1": { "max": 4, "expended": 0 },
-    "2": { "max": 3, "expended": 0 },
-    "3": { "max": 2, "expended": 0 },
-    "4": { "max": 1, "expended": 0 }
+  "spellcasting": {
+    "spellcastingAbility": "",
+    "spellSaveDc": 0,
+    "spellAttackBonus": 0,
+    "spellSlots": {
+      "1": { "max": 4, "expended": 0 },
+      "2": { "max": 3, "expended": 0 },
+      "3": { "max": 2, "expended": 0 },
+      "4": { "max": 1, "expended": 0 }
+    },
+    "knownSpells": ["Magic Missile", "Shield"],
+    "preparedSpells": ["Magic Missile", "Shield"]
   }
 }

--- a/spells.html
+++ b/spells.html
@@ -184,18 +184,79 @@
     </main>
 
     <script type="module">
-        lucide.createIcons();
-        // --- STATE MANAGEMENT (SAMPLE DATA) ---
-        let state = {
-            knownSpells: [], // Array of spell objects from API
-            preparedSpells: ["Magic Missile", "Shield"], // Array of spell names (string)
-            spellSlots: {
-                '1': { max: 4, expended: 0 },
-                '2': { max: 3, expended: 0 },
-                '3': { max: 2, expended: 0 },
-                '4': { max: 1, expended: 0 },
-            },
+        import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
+        import { getFirestore, doc, updateDoc } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+
+        const firebaseConfig = {
+          authDomain: "dnd-shop-app-c4f86.firebaseapp.com",
+          projectId: "dnd-shop-app-c4f86",
+          storageBucket: "dnd-shop-app-c4f86.appspot.com",
+          messagingSenderId: "77441779841",
+          appId: "1:77441779841:web:9f5f0c8cf87ad467601f51"
         };
+        const app = initializeApp(firebaseConfig);
+        const db = getFirestore(app);
+
+        lucide.createIcons();
+
+        const playerDataString = sessionStorage.getItem('currentPlayer');
+        const characterKey = sessionStorage.getItem('currentPlayerKey');
+        let playerData = null;
+
+        let state = {
+            knownSpells: [],
+            preparedSpells: [],
+            spellSlots: {},
+        };
+
+        function toIndex(name) {
+            return name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+        }
+
+        async function loadFromSheet(sheet) {
+            const sc = sheet.spellcasting || {};
+            state.preparedSpells = sc.preparedSpells || [];
+            state.spellSlots = sc.spellSlots || {};
+            const knownNames = sc.knownSpells || [];
+            const spellPromises = knownNames.map(name => getSpellDetails(toIndex(name)));
+            state.knownSpells = (await Promise.all(spellPromises)).filter(Boolean);
+            renderAll();
+        }
+
+        async function initializeState() {
+            if (playerDataString) {
+                try {
+                    playerData = JSON.parse(playerDataString);
+                    await loadFromSheet(playerData.sheet || {});
+                } catch {
+                    const sheet = await fetch('sample-character.json').then(r => r.json());
+                    await loadFromSheet(sheet);
+                }
+            } else {
+                const sheet = await fetch('sample-character.json').then(r => r.json());
+                await loadFromSheet(sheet);
+            }
+        }
+
+        async function saveSpellcasting() {
+            const spellcasting = {
+                spellSlots: state.spellSlots,
+                knownSpells: state.knownSpells.map(s => s.name),
+                preparedSpells: state.preparedSpells
+            };
+            if (playerData) {
+                playerData.sheet = playerData.sheet || {};
+                playerData.sheet.spellcasting = spellcasting;
+                sessionStorage.setItem('currentPlayer', JSON.stringify(playerData));
+            }
+            if (characterKey) {
+                try {
+                    await updateDoc(doc(db, 'characters', characterKey), { 'sheet.spellcasting': spellcasting });
+                } catch (err) {
+                    console.error('Error saving spells:', err);
+                }
+            }
+        }
 
         // --- API FUNCTIONS ---
         const API_BASE = "https://www.dnd5eapi.co/api";
@@ -227,15 +288,6 @@
             }
         }
         
-        // --- INITIAL DATA LOADING ---
-        async function loadInitialSpells() {
-            // Pre-load some spells into the spellbook for the example
-            const initialSpellIndexes = ['magic-missile', 'shield', 'fireball', 'light'];
-            const spellPromises = initialSpellIndexes.map(index => getSpellDetails(index));
-            state.knownSpells = (await Promise.all(spellPromises)).filter(Boolean);
-            renderAll();
-        }
-
         // --- RENDER FUNCTIONS ---
         function renderAll() {
             renderPreparedSpells();
@@ -389,9 +441,10 @@
                 renderSpellbook();
                 const query = document.getElementById('search-input').value.trim();
                 if (query) searchSpellsAPI(query);
+                await saveSpellcasting();
             }
         }
-        
+
         function handlePrepareSpell(e) {
             const spellName = e.target.dataset.spellName;
             if (!spellName) return;
@@ -402,6 +455,7 @@
                 state.preparedSpells.push(spellName);
             }
             renderAll();
+            saveSpellcasting();
         }
 
         function handleCastSpell(e) {
@@ -414,6 +468,7 @@
             if (state.spellSlots[levelStr] && state.spellSlots[levelStr].expended < state.spellSlots[levelStr].max) {
                 state.spellSlots[levelStr].expended++;
                 updateSlotsForLevel(levelStr);
+                saveSpellcasting();
             } else {
                 const originalText = button.textContent;
                 button.textContent = "No Slots!";
@@ -442,6 +497,7 @@
                 levelData.expended = maxSlots - (index + 1);
             }
             updateSlotsForLevel(level);
+            saveSpellcasting();
         }
 
         function handleLongRest() {
@@ -450,6 +506,7 @@
                 updateSlotsForLevel(level);
             }
             renderPreparedSpells(); // Rerender to show all cast buttons again
+            saveSpellcasting();
         }
 
         function handleToggleSpellDetails(e) {
@@ -461,8 +518,7 @@
 
         // --- INITIALIZATION ---
         document.addEventListener('DOMContentLoaded', () => {
-            loadInitialSpells();
-
+            initializeState();
             document.getElementById('search-btn').addEventListener('click', () => {
                 const query = document.getElementById('search-input').value.trim();
                 if (query) searchSpellsAPI(query);


### PR DESCRIPTION
## Summary
- Read known and prepared spells from each character's JSON
- Persist learned and prepared spells back to character data
- Remove placeholder values so sheet renders only data from JSON

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a147e2bf28832a914a7b7c2feac5b0