### PR TITLE
Sync player combat tracker with DM battle tracker

### DIFF
--- a/dm-initiative.html
+++ b/dm-initiative.html
@@ -149,6 +149,18 @@
         const showEnemyHPCheckbox = document.getElementById('show-enemy-hp-checkbox');
         const sessionIdDisplay = document.getElementById('session-id');
 
+        const broadcastChannel = new BroadcastChannel('initiative_tracker');
+
+        function broadcastState() {
+            broadcastChannel.postMessage({
+                combatants: state.combatants,
+                currentTurn: state.currentTurn,
+                round: state.round,
+                combatStarted: state.combatStarted,
+                showEnemyHP: state.showEnemyHP,
+            });
+        }
+
         function renderTracker() {
             if (state.combatStarted) {
                 state.combatants.sort((a, b) => b.initiative - a.initiative);
@@ -203,6 +215,7 @@
             updateControls();
             lucide.createIcons();
             attachCombatantListeners();
+            broadcastState();
         }
         
         function updateControls() {

--- a/player-initiative.html
+++ b/player-initiative.html
@@ -53,6 +53,8 @@
         const combatantsList = document.getElementById('combatants-list');
         const roundCounter = document.getElementById('round-counter');
 
+        const broadcastChannel = new BroadcastChannel('initiative_tracker');
+
         function renderPlayerView() {
             if (!combatState.combatStarted || combatState.combatants.length === 0) {
                 combatantsList.innerHTML = '<p class="text-dim text-center">Waiting for combat to start...</p>';
@@ -102,7 +104,9 @@
         }
 
         function listenForUpdates() {
-            // TODO: implement real-time updates from server
+            broadcastChannel.onmessage = (event) => {
+                updateCombatState(event.data);
+            };
         }
 
         document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- Broadcast DM tracker state via `BroadcastChannel`
- Listen for tracker updates on the player view for live synchronization

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a15c02ed6c832a9338d0879e61ec53