### PR TITLE
Sync combat tracker via Firestore

### DIFF
--- a/dm-initiative.html
+++ b/dm-initiative.html
@@ -104,8 +104,21 @@
     </div>
 
     <script type="module">
-        // Firebase setup would go here in a real app
-        // These utility functions should be replaced with real data access in production.
+        import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
+        import { getFirestore, doc, getDoc, setDoc } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+
+        const firebaseConfig = {
+          apiKey: "AIzaSyA4KsHgYxihH0fgsSET1kcnONHxtlInZIE",
+          authDomain: "dnd-shop-app-c4f86.firebaseapp.com",
+          projectId: "dnd-shop-app-c4f86",
+          storageBucket: "dnd-shop-app-c4f86.appspot.com",
+          messagingSenderId: "480358969004",
+          appId: "1:480358969004:web:51e08541ec64dc4b4a7909",
+          measurementId: "G-DWLMWMZTZ3"
+        };
+
+        const app = initializeApp(firebaseConfig);
+        const db = getFirestore(app);
 
         async function fetchPlayers() {
             // TODO: Replace with real data source
@@ -148,17 +161,12 @@
         const closeStatusModalBtn = document.getElementById('close-status-modal-btn');
         const showEnemyHPCheckbox = document.getElementById('show-enemy-hp-checkbox');
         const sessionIdDisplay = document.getElementById('session-id');
+        const combatId = sessionStorage.getItem('currentCombatId') || Math.random().toString(36).substring(2, 8);
+        sessionStorage.setItem('currentCombatId', combatId);
+        const combatDocRef = doc(db, 'combatSessions', combatId);
 
-        const broadcastChannel = new BroadcastChannel('initiative_tracker');
-
-        function broadcastState() {
-            broadcastChannel.postMessage({
-                combatants: state.combatants,
-                currentTurn: state.currentTurn,
-                round: state.round,
-                combatStarted: state.combatStarted,
-                showEnemyHP: state.showEnemyHP,
-            });
+        async function broadcastState() {
+            await setDoc(combatDocRef, state);
         }
 
         function renderTracker() {
@@ -425,10 +433,18 @@
             });
         }
 
-        document.addEventListener('DOMContentLoaded', () => {
-            sessionIdDisplay.textContent = 'TBD'; // Replace with real session ID
+        document.addEventListener('DOMContentLoaded', async () => {
+            sessionIdDisplay.textContent = combatId;
             statusSelect.innerHTML = statusEffectOptions.map(s => `<option value="${s}">${s}</option>`).join('');
-            
+
+            const existing = await getDoc(combatDocRef);
+            if (existing.exists()) {
+                state = { ...state, ...existing.data() };
+            } else {
+                await setDoc(combatDocRef, state);
+            }
+            showEnemyHPCheckbox.checked = state.showEnemyHP;
+
             addPlayersBtn.addEventListener('click', addPlayers);
             addEnemyBtn.addEventListener('click', addEnemy);
             startCombatBtn.addEventListener('click', startCombat);
@@ -440,7 +456,7 @@
             closeStatusModalBtn.addEventListener('click', () => statusEffectModal.classList.add('hidden'));
             showEnemyHPCheckbox.addEventListener('change', (e) => {
                 state.showEnemyHP = e.target.checked;
-                // TODO: persist this preference
+                renderTracker();
             });
 
             renderTracker();

--- a/player-initiative.html
+++ b/player-initiative.html
@@ -39,8 +39,21 @@
     </div>
 
     <script type="module">
-        // In production, subscribe to real-time combat state from the backend.
-        // This placeholder simply updates the DOM when combatState changes.
+        import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
+        import { getFirestore, doc, onSnapshot } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+
+        const firebaseConfig = {
+          apiKey: "AIzaSyA4KsHgYxihH0fgsSET1kcnONHxtlInZIE",
+          authDomain: "dnd-shop-app-c4f86.firebaseapp.com",
+          projectId: "dnd-shop-app-c4f86",
+          storageBucket: "dnd-shop-app-c4f86.appspot.com",
+          messagingSenderId: "480358969004",
+          appId: "1:480358969004:web:51e08541ec64dc4b4a7909",
+          measurementId: "G-DWLMWMZTZ3"
+        };
+
+        const app = initializeApp(firebaseConfig);
+        const db = getFirestore(app);
 
         let combatState = {
             combatants: [],
@@ -52,8 +65,6 @@
 
         const combatantsList = document.getElementById('combatants-list');
         const roundCounter = document.getElementById('round-counter');
-
-        const broadcastChannel = new BroadcastChannel('initiative_tracker');
 
         function renderPlayerView() {
             if (!combatState.combatStarted || combatState.combatants.length === 0) {
@@ -103,15 +114,23 @@
             renderPlayerView();
         }
 
-        function listenForUpdates() {
-            broadcastChannel.onmessage = (event) => {
-                updateCombatState(event.data);
-            };
-        }
-
         document.addEventListener('DOMContentLoaded', () => {
             renderPlayerView();
-            listenForUpdates();
+
+            const combatId = sessionStorage.getItem('currentCombatId') || prompt('Enter combat session ID:');
+            if (!combatId) {
+                alert('No combat session ID provided.');
+                return;
+            }
+            sessionStorage.setItem('currentCombatId', combatId);
+            const combatDocRef = doc(db, 'combatSessions', combatId);
+            onSnapshot(combatDocRef, (docSnap) => {
+                if (docSnap.exists()) {
+                    updateCombatState(docSnap.data());
+                } else {
+                    combatantsList.innerHTML = '<p class="text-dim text-center">Waiting for combat to start...</p>';
+                }
+            });
         });
 
     </script>


### PR DESCRIPTION
## Summary
- Broadcast DM initiative tracker state through Firestore documents keyed by a combat session ID
- Player initiative view subscribes to the combat session document for live updates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a15dc0af10832aa69edc61b8a5908c