### PR TITLE
fix: sync player tracker when combat begins

### DIFF
--- a/player-initiative.html
+++ b/player-initiative.html
@@ -507,6 +507,18 @@
         document.addEventListener('DOMContentLoaded', () => {
             loadPlayerSheet();
 
+            // Subscribe immediately if a combat session was already active.
+            const existingId = sessionStorage.getItem('currentCombatId');
+            if (existingId) {
+                const existingRef = doc(db, 'combatSessions', existingId);
+                combatUnsub = onSnapshot(existingRef, (snap) => {
+                    if (snap.exists()) {
+                        hadCombat = true;
+                        updateCombatState(snap.data());
+                    }
+                });
+            }
+
             const activeCombatRef = doc(db, 'currentCombat', 'active');
             onSnapshot(activeCombatRef, (activeSnap) => {
                 const combatId = activeSnap.exists() ? activeSnap.data().id : null;


### PR DESCRIPTION
## Summary
- subscribe player tracker to existing combat session
- ensure player tracker updates when DM starts combat

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a37574c1cc832ab50bc9326c006372