### PR TITLE
Ensure spell slot updates sync across views

### DIFF
--- a/character.html
+++ b/character.html
@@ -603,6 +603,11 @@
             onSnapshot(playerDocRef, (docSnap) => {
                 if (docSnap.exists()) {
                     playerData = docSnap.data();
+                    try {
+                        sessionStorage.setItem('currentPlayer', JSON.stringify(playerData));
+                        const slots = playerData.sheet?.spellcasting?.spellSlots;
+                        if (slots) { localStorage.setItem('spellSlots', JSON.stringify(slots)); }
+                    } catch {}
                     const sheet = playerData.sheet;
                     if (sheet) {
                         renderCharacter(sheet, playerData);

--- a/index.html
+++ b/index.html
@@ -343,7 +343,17 @@
 
         // Debounced saver: localStorage immediately, Firestore after quiet period
         window.saveSpellSlotsDebounced = async function saveSpellSlotsDebounced(slots) {
-            try { localStorage.setItem('spellSlots', JSON.stringify(slots)); } catch {}
+            try {
+                localStorage.setItem('spellSlots', JSON.stringify(slots));
+                const playerStr = sessionStorage.getItem('currentPlayer');
+                if (playerStr) {
+                    const player = JSON.parse(playerStr);
+                    player.sheet = player.sheet || {};
+                    player.sheet.spellcasting = player.sheet.spellcasting || {};
+                    player.sheet.spellcasting.spellSlots = slots;
+                    sessionStorage.setItem('currentPlayer', JSON.stringify(player));
+                }
+            } catch {}
             if (saveSlotsDebounceTimer) clearTimeout(saveSlotsDebounceTimer);
             saveSlotsDebounceTimer = setTimeout(async () => {
                 try {
@@ -557,6 +567,10 @@
 
                     // Update state early so downstream reads see latest
                     state.playerData = data;
+                    try {
+                        sessionStorage.setItem('currentPlayer', JSON.stringify(state.playerData));
+                        sessionStorage.setItem('currentPlayerKey', state.characterKey);
+                    } catch {}
 
                     const slotsPrev = prev?.sheet?.spellcasting?.spellSlots || {};
                     const slotsNext = data?.sheet?.spellcasting?.spellSlots || {};

--- a/player-initiative.html
+++ b/player-initiative.html
@@ -448,6 +448,17 @@
             if (!playerDocRef) return;
             try {
                 await updateDoc(playerDocRef, { 'sheet.spellcasting.spellSlots': state.spellSlots });
+                try {
+                    localStorage.setItem('spellSlots', JSON.stringify(state.spellSlots));
+                    const playerStr = sessionStorage.getItem('currentPlayer');
+                    if (playerStr) {
+                        const player = JSON.parse(playerStr);
+                        player.sheet = player.sheet || {};
+                        player.sheet.spellcasting = player.sheet.spellcasting || {};
+                        player.sheet.spellcasting.spellSlots = state.spellSlots;
+                        sessionStorage.setItem('currentPlayer', JSON.stringify(player));
+                    }
+                } catch {}
             } catch (err) {
                 console.error('Failed to save spell slots', err);
             }


### PR DESCRIPTION
## Summary
- Sync player data to sessionStorage whenever Firestore snapshots update
- Persist spell slot changes from combat tracker to local and session storage
- Update character sheet snapshot handler to refresh cached player data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b2f305d8832a8d732ece9687df51