### PR TITLE
feat: add hp animations to player battle tracker

### DIFF
--- a/player-initiative.html
+++ b/player-initiative.html
@@ -82,6 +82,7 @@
         .combatant-list-item {
             transition: all 0.3s ease-in-out;
             border-left: 4px solid transparent;
+            position: relative;
         }
 
         .combatant-list-item.active {
@@ -125,6 +126,44 @@
             box-shadow: none;
         }
         .cast-btn { background-color: var(--color-bg); white-space: nowrap; }
+
+        /* Health Change Animations */
+        .hp-change-animation {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            font-size: 2.5rem;
+            font-weight: bold;
+            opacity: 0;
+            pointer-events: none;
+            animation: float-up-fade 1.5s ease-out forwards;
+        }
+        .hp-damage { color: #ef4444; text-shadow: 0 0 5px #ef4444; }
+        .hp-heal { color: #22c55e; text-shadow: 0 0 5px #22c55e; }
+
+        @keyframes float-up-fade {
+            0% { opacity: 1; transform: translate(-50%, -50%) scale(0.8); }
+            100% { opacity: 0; transform: translate(-50%, -200%) scale(1.2); }
+        }
+
+        .flash-damage { animation: flash-red 0.5s ease-out; }
+        .flash-heal { animation: flash-green 0.5s ease-out; }
+        .shake { animation: shake-horizontal 0.4s ease-in-out; }
+
+        @keyframes flash-red {
+            0%, 100% { background-color: transparent; }
+            50% { background-color: rgba(239, 68, 68, 0.3); }
+        }
+        @keyframes flash-green {
+            0%, 100% { background-color: transparent; }
+            50% { background-color: rgba(34, 197, 94, 0.3); }
+        }
+        @keyframes shake-horizontal {
+            0%, 100% { transform: translateX(0); }
+            10%, 30%, 50%, 70%, 90% { transform: translateX(-5px); }
+            20%, 40%, 60%, 80% { transform: translateX(5px); }
+        }
 
         /* Roll Result Modal */
         #roll-result-modal {
@@ -244,6 +283,7 @@
             combatStarted: false,
             showEnemyHP: false,
         };
+        const lastHpMap = new Map();
 
         // Player sheet state
         let playerSheet = null;
@@ -327,6 +367,7 @@
 
                 const listItem = document.createElement('div');
                 listItem.className = `combatant-list-item p-3 rounded-md ${isActive ? 'active' : ''} ${c.downed ? 'downed' : ''}`;
+                listItem.dataset.id = c.id;
 
                 listItem.innerHTML = `
                     <div class="flex items-center gap-4">
@@ -343,9 +384,40 @@
             lucide.createIcons();
         }
 
+        function playHpAnimation(id, amount, type) {
+            const combatantEl = document.querySelector(`.combatant-list-item[data-id="${id}"]`);
+            if (!combatantEl) return;
+
+            const animationEl = document.createElement('div');
+            animationEl.textContent = `${type === 'damage' ? '-' : '+'}${amount}`;
+            animationEl.className = `hp-change-animation ${type === 'damage' ? 'hp-damage' : 'hp-heal'}`;
+            combatantEl.appendChild(animationEl);
+
+            combatantEl.classList.add(type === 'damage' ? 'flash-damage' : 'flash-heal');
+            if (type === 'damage') combatantEl.classList.add('shake');
+
+            setTimeout(() => {
+                animationEl.remove();
+                combatantEl.classList.remove('flash-damage', 'flash-heal', 'shake');
+            }, 1500);
+        }
+
         function updateCombatState(newState) {
+            const prevHpMap = new Map(lastHpMap);
             combatState = { ...combatState, ...newState };
             renderCombatOrder();
+
+            combatState.combatants.forEach(c => {
+                if (c.hp !== null) {
+                    const prev = prevHpMap.get(c.id);
+                    if (prev !== undefined && prev !== c.hp) {
+                        const amount = Math.abs(c.hp - prev);
+                        const type = c.hp < prev ? 'damage' : 'heal';
+                        playHpAnimation(c.id, amount, type);
+                    }
+                    lastHpMap.set(c.id, c.hp);
+                }
+            });
         }
 
         // Attacks rendering


### PR DESCRIPTION
## Summary
- show hp animations on player combat tracker
- track previous hp to animate damage and healing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b9aa31a0832aa7640aee8763ab7e