### PR TITLE
Return to character hub from sheet

### DIFF
--- a/character.html
+++ b/character.html
@@ -123,7 +123,7 @@
     <div id="toolbar" class="fixed top-0 left-0 right-0 p-4 z-50 flex justify-between items-center h-20 bg-[#0A0A0A]">
         <div id="toolbar-title" class="text-2xl hidden text-header"></div>
         <div id="controls-container" class="relative ml-auto flex items-center gap-4">
-             <button id="exit-mode-btn" onclick="history.back()"><i data-lucide="x" class="w-6 h-6"></i></button>
+             <button id="exit-mode-btn" onclick="window.location.href='index.html'"><i data-lucide="x" class="w-6 h-6"></i></button>
         </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -478,6 +478,15 @@
             if (savedKey) {
                 document.getElementById('character-key-input').value = savedKey;
             }
+
+            // Restore previous character session if available
+            const sessionPlayer = sessionStorage.getItem('currentPlayer');
+            const sessionKey = sessionStorage.getItem('currentPlayerKey');
+            if (sessionPlayer && sessionKey) {
+                state.characterKey = sessionKey;
+                state.playerData = JSON.parse(sessionPlayer);
+                listenToPlayerData(sessionKey);
+            }
             listenToActiveShops();
             render();
         }


### PR DESCRIPTION
## Summary
- Restore previous character session on index load from sessionStorage and reattach live listener
- Redirect character sheet's close button to the character hub instead of using browser history

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af8e396200832abaa8c67fd0f47f73