### PR TITLE
Add shared dice roller for DM and players

### DIFF
--- a/dm-initiative.html
+++ b/dm-initiative.html
@@ -68,6 +68,15 @@
             10%, 30%, 50%, 70%, 90% { transform: translateX(-5px); }
             20%, 40%, 60%, 80% { transform: translateX(5px); }
         }
+        /* Roll Result Modal */
+        #roll-result-modal {
+            transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out;
+        }
+        #roll-result-modal.hidden {
+            opacity: 0;
+            transform: translateY(20px);
+            pointer-events: none;
+        }
     </style>
 </head>
 <body class="p-4 sm:p-6 lg:p-8">
@@ -121,6 +130,13 @@
                                 <button id="hp-heal-btn" class="btn !p-3 bg-green-800 hover:!bg-green-700 !text-white" title="Heal"><i data-lucide="plus" class="w-5 h-5"></i></button>
                             </div>
                         </div>
+                        <div class="pt-3 border-t border-border">
+                            <h3 class="text-xl text-accent mb-2">&gt; Dice Roller</h3>
+                            <div class="flex gap-2">
+                                <input id="dm-dice-input" type="text" class="input-field flex-grow" placeholder="e.g. 1d20+5">
+                                <button id="dm-roll-btn" class="btn">Roll</button>
+                            </div>
+                        </div>
                         <div class="pt-3 border-t border-border flex items-center justify-center gap-2 text-sm"><input id="show-enemy-hp-checkbox" type="checkbox" class="h-4 w-4"><label for="show-enemy-hp-checkbox">Show Enemy HP to Players</label></div>
                         <button id="end-combat-btn" class="btn-secondary w-full mt-4">End Combat</button>
                      </div>
@@ -142,13 +158,22 @@
                 <select id="status-select" class="input-field !text-white"></select>
                 <input id="status-duration-input" type="number" class="input-field" placeholder="Duration in rounds (optional)">
                 <button id="add-status-btn" class="btn w-full">Add Effect</button>
-             </div>
-        </div>
+            </div>
+       </div>
+    </div>
+
+    <!-- Roll Result Modal -->
+    <div id="roll-result-modal" class="hidden fixed bottom-5 right-5 bg-black border-2 border-header rounded-lg shadow-lg p-4 z-[100] w-64">
+        <button id="close-roll-modal-btn" class="absolute top-1 right-1 text-accent hover:text-header">&times;</button>
+        <h3 id="roll-title" class="text-lg text-header">Roll Result</h3>
+        <p id="roll-details" class="text-sm text-dim"></p>
+        <p id="roll-total" class="text-4xl text-price text-center my-2"></p>
     </div>
 
     <script type="module">
         import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
         import { getFirestore, doc, getDoc, setDoc, getDocs, collection } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+        import { rollExpr } from './dice.js';
 
         const firebaseConfig = {
           apiKey: "AIzaSyA4KsHgYxihH0fgsSET1kcnONHxtlInZIE",
@@ -206,12 +231,54 @@
         const addStatusBtn = document.getElementById('add-status-btn');
         const closeStatusModalBtn = document.getElementById('close-status-modal-btn');
         const showEnemyHPCheckbox = document.getElementById('show-enemy-hp-checkbox');
+        const dmDiceInput = document.getElementById('dm-dice-input');
+        const dmRollBtn = document.getElementById('dm-roll-btn');
+        const rollResultModal = document.getElementById('roll-result-modal');
         const sessionIdDisplay = document.getElementById('session-id');
         const combatId = sessionStorage.getItem('currentCombatId') || Math.random().toString(36).substring(2, 8);
         sessionStorage.setItem('currentCombatId', combatId);
         const combatDocRef = doc(db, 'combatSessions', combatId);
         const activeCombatRef = doc(db, 'currentCombat', 'active');
         setDoc(activeCombatRef, { id: combatId });
+
+        // Dice rolling
+        function rollDice(expr) {
+            try {
+                return { expr, ...rollExpr(expr) };
+            } catch {
+                return { expr, total: 0, rolls: [] };
+            }
+        }
+
+        function animateRoll(max, final) {
+            const totalEl = document.getElementById('roll-total');
+            let current = 1;
+            totalEl.classList.add('animate-pulse');
+            const interval = setInterval(() => {
+                totalEl.textContent = current;
+                current = current >= max ? 1 : current + 1;
+            }, 50);
+            setTimeout(() => {
+                clearInterval(interval);
+                totalEl.classList.remove('animate-pulse');
+                totalEl.textContent = final;
+            }, 800);
+        }
+
+        function showRollResult(title, result) {
+            document.getElementById('roll-title').textContent = title;
+            const base = result.rolls.reduce((a, b) => a + b, 0);
+            const mod = result.total - base;
+            let details = `Rolled: ${result.expr} -> [${result.rolls.join(', ')}]`;
+            if (mod) details += ` ${mod > 0 ? '+' : ''} ${mod}`;
+            document.getElementById('roll-details').textContent = details;
+            const max = result.rolls.length ? Math.max(result.total, ...result.rolls) : result.total;
+            animateRoll(max, result.total);
+            rollResultModal.classList.remove('hidden');
+            setTimeout(() => rollResultModal.classList.add('hidden'), 4000);
+        }
+
+        document.getElementById('close-roll-modal-btn').addEventListener('click', () => rollResultModal.classList.add('hidden'));
 
         async function broadcastState() {
             await setDoc(combatDocRef, state);
@@ -554,6 +621,12 @@
             hpHealBtn.addEventListener('click', () => modifySelectedCombatantHP('heal'));
             addStatusBtn.addEventListener('click', addStatusEffect);
             closeStatusModalBtn.addEventListener('click', () => statusEffectModal.classList.add('hidden'));
+            dmRollBtn.addEventListener('click', () => {
+                const expr = dmDiceInput.value.trim();
+                if (!expr) return;
+                const result = rollDice(expr);
+                showRollResult('Dice Roll', result);
+            });
             showEnemyHPCheckbox.addEventListener('change', (e) => {
                 state.showEnemyHP = e.target.checked;
                 renderTracker();

--- a/player-initiative.html
+++ b/player-initiative.html
@@ -211,6 +211,14 @@
             <div class="cli-window">
                  <a href="character.html" id="character-sheet-link" class="btn w-full text-center">View Full Character Sheet</a>
             </div>
+            <!-- Dice Roller -->
+            <div class="cli-window">
+                <h2 class="text-2xl text-header mb-4">&gt; Dice Roller</h2>
+                <div class="flex gap-2">
+                    <input id="player-dice-input" type="text" class="input-field flex-grow" placeholder="e.g. 1d20+5">
+                    <button id="player-roll-btn" class="btn">Roll</button>
+                </div>
+            </div>
             <!-- Attacks Widget -->
             <div class="cli-window">
                 <h2 class="text-2xl text-header mb-4">&gt; Attacks</h2>
@@ -259,6 +267,7 @@
     <script type="module">
         import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
         import { getFirestore, doc, onSnapshot, getDoc, updateDoc } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+        import { rollExpr } from './dice.js';
 
         const firebaseConfig = {
           apiKey: "AIzaSyA4KsHgYxihH0fgsSET1kcnONHxtlInZIE",
@@ -300,32 +309,16 @@
         const spellSlotsContainer = document.getElementById('spell-slots-container');
         const longRestBtn = document.getElementById('long-rest-btn');
         const rollResultModal = document.getElementById('roll-result-modal');
+        const playerDiceInput = document.getElementById('player-dice-input');
+        const playerRollBtn = document.getElementById('player-roll-btn');
 
         // Dice rolling
-        function rollDice(diceString) {
-            if (!diceString || typeof diceString !== 'string') {
-                return { total: 0, rolls: [], modifier: 0, diceString: 'Invalid', maxRoll: 0 };
+        function rollDice(expr) {
+            try {
+                return { expr, ...rollExpr(expr) };
+            } catch {
+                return { expr, total: 0, rolls: [] };
             }
-            const cleanedString = diceString.replace(/\s+/g, '');
-            const match = cleanedString.match(/(\d+)d(\d+)([+-]\d+)?/);
-            if (!match) {
-                const flatNumber = parseInt(cleanedString, 10);
-                return isNaN(flatNumber)
-                    ? { total: 0, rolls: [], modifier: 0, diceString: cleanedString, maxRoll: 0 }
-                    : { total: flatNumber, rolls: [flatNumber], modifier: 0, diceString: cleanedString, maxRoll: flatNumber };
-            }
-            const numDice = parseInt(match[1], 10);
-            const numSides = parseInt(match[2], 10);
-            const modifier = match[3] ? parseInt(match[3], 10) : 0;
-            let total = 0;
-            const rolls = [];
-            for (let i = 0; i < numDice; i++) {
-                const roll = Math.floor(Math.random() * numSides) + 1;
-                rolls.push(roll);
-                total += roll;
-            }
-            total += modifier;
-            return { total, rolls, modifier, diceString: cleanedString, maxRoll: numSides };
         }
 
         function animateRoll(max, final) {
@@ -345,12 +338,15 @@
 
         function showRollResult(title, result) {
             document.getElementById('roll-title').textContent = title;
-            let details = `Rolled: ${result.diceString} -> [${result.rolls.join(', ')}]`;
-            if (result.modifier) {
-                details += ` ${result.modifier > 0 ? '+' : ''} ${result.modifier}`;
+            const base = result.rolls.reduce((a, b) => a + b, 0);
+            const mod = result.total - base;
+            let details = `Rolled: ${result.expr} -> [${result.rolls.join(', ')}]`;
+            if (mod) {
+                details += ` ${mod > 0 ? '+' : ''} ${mod}`;
             }
             document.getElementById('roll-details').textContent = details;
-            animateRoll(result.maxRoll || result.total, result.total);
+            const max = result.rolls.length ? Math.max(result.total, ...result.rolls) : result.total;
+            animateRoll(max, result.total);
             rollResultModal.classList.remove('hidden');
             setTimeout(() => rollResultModal.classList.add('hidden'), 4000);
         }
@@ -661,6 +657,12 @@
             });
             spellSlotsContainer.addEventListener('click', handleSlotClick);
             longRestBtn.addEventListener('click', handleLongRest);
+            playerRollBtn.addEventListener('click', () => {
+                const expr = playerDiceInput.value.trim();
+                if (!expr) return;
+                const result = rollDice(expr);
+                showRollResult('Dice Roll', result);
+            });
 
             lucide.createIcons();
         });


### PR DESCRIPTION
## Summary
- Add reusable dice roller sections for both player and DM initiative trackers
- Wire up dice.js `rollExpr` to power rolls and show results in a modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af93faa2d8832a8615cfed75d5b70d