### PR TITLE
Restore combat roll and spell slot controls

### DIFF
--- a/player-initiative.html
+++ b/player-initiative.html
@@ -371,19 +371,62 @@
                 attacksContainer.innerHTML = '<p class="text-dim">> No attacks listed.</p>';
                 return;
             }
-            sheet.attacks.forEach(attack => {
+            sheet.attacks.forEach((attack, index) => {
                 const attackEl = document.createElement('div');
                 attackEl.className = 'grid grid-cols-3 gap-4 border-t border-border pt-2 items-center';
                 attackEl.innerHTML = `
                     <p>${attack.name}</p>
                     <div class="flex items-center gap-2">
                         <span>${attack.atkBonus}</span>
+                        <button class="roll-btn text-dim hover:text-accent" data-type="hit" data-index="${index}" title="Roll to hit">
+                            <i data-lucide="dice-5" class="w-4 h-4"></i>
+                        </button>
                     </div>
                     <div class="flex items-center gap-2">
                         <span>${attack.damage}</span>
+                        <button class="roll-btn text-dim hover:text-accent" data-type="damage" data-index="${index}" title="Roll damage">
+                            <i data-lucide="dice-5" class="w-4 h-4"></i>
+                        </button>
                     </div>`;
                 attacksContainer.appendChild(attackEl);
             });
+            attacksContainer.querySelectorAll('.roll-btn').forEach(btn => {
+                btn.addEventListener('click', handleRollBtn);
+            });
+            lucide.createIcons();
+        }
+
+        function rollExpression(notation) {
+            const expr = notation.trim().split(/\s+/)[0];
+            const dicePattern = /(\d*)d(\d+)/gi;
+            const replaced = expr.replace(dicePattern, (_, count, sides) => {
+                count = parseInt(count) || 1;
+                let total = 0;
+                for (let i = 0; i < count; i++) {
+                    total += Math.floor(Math.random() * sides) + 1;
+                }
+                return total;
+            });
+            try {
+                return Function(`return ${replaced}`)();
+            } catch {
+                return NaN;
+            }
+        }
+
+        function handleRollBtn(e) {
+            const index = e.currentTarget.dataset.index;
+            const type = e.currentTarget.dataset.type;
+            const attack = playerSheet.attacks[index];
+            if (!attack) return;
+            if (type === 'hit') {
+                const bonus = parseInt(attack.atkBonus) || 0;
+                const result = rollExpression(`1d20+${bonus}`);
+                alert(`${attack.name} to hit: ${result}`);
+            } else {
+                const result = rollExpression(attack.damage);
+                alert(`${attack.name} damage: ${result}`);
+            }
         }
 
         // Spell helpers
@@ -429,6 +472,7 @@
                     <div class="flex items-center justify-start gap-4" data-level-bar="${level}">
                         <span class="text-accent w-20">Lvl ${level}</span>
                         <div class="slot-bar">${slotBarHtml}</div>
+                        <button class="cast-slot-btn border border-header px-2 py-1 rounded text-header hover:bg-header hover:text-black" data-level="${level}">Cast</button>
                     </div>`;
             }
         }
@@ -489,6 +533,10 @@
         }
         
         function handleSlotClick(e) {
+            if (e.target.classList.contains('cast-slot-btn')) {
+                handleCastSlot(e.target.dataset.level);
+                return;
+            }
             if (!e.target.classList.contains('slot-segment')) return;
             const level = e.target.dataset.level;
             const index = Number(e.target.dataset.index);
@@ -501,6 +549,15 @@
             } else {
                 slot.expended = maxSlots - (index + 1);
             }
+            saveSpellSlots();
+            renderSpellSlots();
+            renderPreparedSpells();
+        }
+
+        function handleCastSlot(level) {
+            const slot = state.spellSlots[level];
+            if (!slot || slot.expended >= slot.max) return;
+            slot.expended++;
             saveSpellSlots();
             renderSpellSlots();
             renderPreparedSpells();


### PR DESCRIPTION
## Summary
- reintroduce dice roll buttons for attack to-hit and damage
- add spell slot cast buttons and management

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afa16e05b0832a95b688a26f78f882